### PR TITLE
Can pass options to Rufus::Scheduler.new

### DIFF
--- a/lib/sidekiq/scheduler.rb
+++ b/lib/sidekiq/scheduler.rb
@@ -131,8 +131,16 @@ module Sidekiq
        Sidekiq::Client.push(config)
     end
 
+    def self.rufus_scheduler_options
+      @rufus_scheduler_options ||= {}
+    end
+
+    def self.rufus_scheduler_options=(options)
+      @rufus_scheduler_options = options
+    end
+
     def self.rufus_scheduler
-      @rufus_scheduler ||= Rufus::Scheduler.new
+      @rufus_scheduler ||= Rufus::Scheduler.new rufus_scheduler_options
     end
 
     # Stops old rufus scheduler and creates a new one.  Returns the new

--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'sidekiq',         '~> 3', '>= 2.12'
   s.add_dependency 'redis',           '~> 3'
-  s.add_dependency 'rufus-scheduler', '~> 2'
+  s.add_dependency 'rufus-scheduler', '~> 3'
   s.add_dependency 'multi_json',      '~> 1'
 
   s.add_development_dependency 'rake',        '~> 10.0'

--- a/test/lib/sidekiq/scheduler_test.rb
+++ b/test/lib/sidekiq/scheduler_test.rb
@@ -67,7 +67,15 @@ class ManagerTest < Minitest::Test
       assert Sidekiq::Scheduler.scheduled_jobs.include?(:some_ivar_job)
     end
 
-    # THIS
+    it 'can pass options to the Rufus scheduler instance' do
+      options = { :lockfile => '/tmp/rufus_lock' }
+
+      Sidekiq::Scheduler.rufus_scheduler_options = options
+      Rufus::Scheduler.expects(:new).with(options)
+
+      Sidekiq::Scheduler.clear_schedule!
+    end
+
     it 'can reload schedule' do
       Sidekiq::Scheduler.dynamic = true
       Sidekiq.schedule = {

--- a/test/lib/sidekiq/scheduler_test.rb
+++ b/test/lib/sidekiq/scheduler_test.rb
@@ -52,7 +52,7 @@ class ManagerTest < Minitest::Test
     end
 
     it 'config makes it into the rufus_scheduler' do
-      assert_equal(0, Sidekiq::Scheduler.rufus_scheduler.all_jobs.size)
+      assert_equal(0, Sidekiq::Scheduler.rufus_scheduler.jobs.size)
       Sidekiq.schedule = {
         :some_ivar_job => {
           'cron' => '* * * * *',
@@ -63,7 +63,7 @@ class ManagerTest < Minitest::Test
 
       Sidekiq::Scheduler.load_schedule!
 
-      assert_equal(1, Sidekiq::Scheduler.rufus_scheduler.all_jobs.size)
+      assert_equal(1, Sidekiq::Scheduler.rufus_scheduler.jobs.size)
       assert Sidekiq::Scheduler.scheduled_jobs.include?(:some_ivar_job)
     end
 
@@ -99,7 +99,7 @@ class ManagerTest < Minitest::Test
 
       Sidekiq::Scheduler.reload_schedule!
 
-      assert Sidekiq::Scheduler.scheduled_jobs.include?('some_ivar_job')
+      refute  Sidekiq::Scheduler.scheduled_jobs.include?('some_ivar_job')
       assert Sidekiq::Scheduler.scheduled_jobs.include?('some_ivar_job2')
 
       assert_equal '/tmp/2', Sidekiq.schedule['some_ivar_job2']['args']
@@ -115,7 +115,7 @@ class ManagerTest < Minitest::Test
         }
       )
 
-      assert_equal(1, Sidekiq::Scheduler.rufus_scheduler.all_jobs.size)
+      assert_equal(1, Sidekiq::Scheduler.rufus_scheduler.jobs.size)
       assert_equal(1, Sidekiq::Scheduler.scheduled_jobs.size)
       assert Sidekiq::Scheduler.scheduled_jobs.keys.include?('some_ivar_job')
     end
@@ -130,7 +130,7 @@ class ManagerTest < Minitest::Test
         }
       )
 
-      assert_equal(1, Sidekiq::Scheduler.rufus_scheduler.all_jobs.size)
+      assert_equal(1, Sidekiq::Scheduler.rufus_scheduler.jobs.size)
       assert_equal(1, Sidekiq::Scheduler.scheduled_jobs.size)
       assert Sidekiq::Scheduler.scheduled_jobs.keys.include?('some_ivar_job')
       assert Sidekiq::Scheduler.scheduled_jobs['some_ivar_job'].params.keys.include?(:first_in)
@@ -146,7 +146,7 @@ class ManagerTest < Minitest::Test
         }
       )
 
-      assert_equal(1, Sidekiq::Scheduler.rufus_scheduler.all_jobs.size)
+      assert_equal(1, Sidekiq::Scheduler.rufus_scheduler.jobs.size)
       assert_equal(1, Sidekiq::Scheduler.scheduled_jobs.size)
       assert Sidekiq::Scheduler.scheduled_jobs.keys.include?('some_ivar_job')
       assert Sidekiq::Scheduler.scheduled_jobs['some_ivar_job'].params.keys.include?(:allow_overlapping)
@@ -161,7 +161,7 @@ class ManagerTest < Minitest::Test
         }
       )
 
-      assert_equal(0, Sidekiq::Scheduler.rufus_scheduler.all_jobs.size)
+      assert_equal(0, Sidekiq::Scheduler.rufus_scheduler.jobs.size)
       assert_equal(0, Sidekiq::Scheduler.scheduled_jobs.size)
       assert !Sidekiq::Scheduler.scheduled_jobs.keys.include?('some_ivar_job')
     end
@@ -176,7 +176,7 @@ class ManagerTest < Minitest::Test
         }
       )
 
-      assert_equal(0, Sidekiq::Scheduler.rufus_scheduler.all_jobs.size)
+      assert_equal(0, Sidekiq::Scheduler.rufus_scheduler.jobs.size)
       assert_equal(0, Sidekiq::Scheduler.scheduled_jobs.size)
       assert !Sidekiq::Scheduler.scheduled_jobs.keys.include?('some_ivar_job')
     end


### PR DESCRIPTION
I want to pass in some `:lockfile` options to the scheduler. This allows for any options to be set.

As part of the PR, I also updated to rufus-scheduler 3.0+, which has better options other than subclassing Rufus::Scheduler to add different locking semantics.

