### PR TITLE
Fix "every" syntax example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ is most likely stored in a YAML like so:
     queue_documents_for_indexing:
       cron: "0 0 * * *"
       # you can use rufus-scheduler "every" syntax in place of cron if you prefer
-      # every: 1hr
+      # every: 1h
       # By default the job name (hash key) will be taken as worker class name.
       # If you want to have a different job name and class name, provide the 'class' option
       class: QueueDocuments


### PR DESCRIPTION
Rufus expects single characters for intervals, as in `1h`.

If we use `1hr`, Rufus seems to still accept it via a `DateTime.parse` fallback. No idea how `DateTime.parse('1hr')` is interpreted, but it gives a different result.