### PR TITLE
allow the use of rufus scheduler methods [at, in]

### DIFF
--- a/lib/sidekiq/scheduler.rb
+++ b/lib/sidekiq/scheduler.rb
@@ -72,7 +72,7 @@ module Sidekiq
       if config['rails_env'].nil? || self.rails_env_matches?(config)
         logger.info "Scheduling #{name} "
         interval_defined = false
-        interval_types = %w{cron every}
+        interval_types = %w{cron every at in}
         interval_types.each do |interval_type|
           if !config[interval_type].nil? && config[interval_type].length > 0
             args = self.optionizate_interval_value(config[interval_type])

--- a/test/lib/sidekiq/scheduler_test.rb
+++ b/test/lib/sidekiq/scheduler_test.rb
@@ -152,6 +152,36 @@ class ManagerTest < Minitest::Test
       assert Sidekiq::Scheduler.scheduled_jobs['some_ivar_job'].params.keys.include?(:allow_overlapping)
     end
 
+    it 'load_schedule_job with at' do
+      Sidekiq::Scheduler.load_schedule_job(
+        'some_ivar_job',
+        {
+          'at' => "2013/12/12 12:30",
+          'class' => 'SomeIvarJob',
+          'args' => '/tmp'
+        }
+      )
+
+      assert_equal(1, Sidekiq::Scheduler.rufus_scheduler.all_jobs.size)
+      assert_equal(1, Sidekiq::Scheduler.scheduled_jobs.size)
+      assert Sidekiq::Scheduler.scheduled_jobs.keys.include?('some_ivar_job')
+    end
+
+    it 'load_schedule_job with in' do
+      Sidekiq::Scheduler.load_schedule_job(
+        'some_ivar_job',
+        {
+          'in' => "10d",
+          'class' => 'SomeIvarJob',
+          'args' => '/tmp'
+        }
+      )
+
+      assert_equal(1, Sidekiq::Scheduler.rufus_scheduler.all_jobs.size)
+      assert_equal(1, Sidekiq::Scheduler.scheduled_jobs.size)
+      assert Sidekiq::Scheduler.scheduled_jobs.keys.include?('some_ivar_job')
+    end
+
     it 'does not load the schedule without cron' do
       Sidekiq::Scheduler.load_schedule_job(
         'some_ivar_job',


### PR DESCRIPTION
Rufus scheduler allows the scheduling of jobs to occur one at a specific time such as in the case of an auction that is ending. This pull request adds the specific time methods "at" and "in" as allowable options for sidekiq scheduler.