### PR TITLE
Basic Sidekiq Web UI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,17 @@ from the `config.time_zone` value, make sure it's the right format, e.g. with:
 
 A future version of sidekiq-scheduler may do this for you.
 
+### Sidekiq Web Integration
+
+SidekiqScheduler provides an extension to the Sidekiq web interface that adds a Recurring Jobs page.
+
+To use it, set up the Sidekiq web interface according to the Sidekiq documentation and then add the SidekiqScheduler::Web require:
+
+``` ruby
+require 'sidekiq/web'
+require 'sidekiq-scheduler/web'
+```
+
 ## Note on Patches / Pull Requests
 
 * Fork the project.

--- a/lib/sidekiq-scheduler/web.rb
+++ b/lib/sidekiq-scheduler/web.rb
@@ -1,0 +1,19 @@
+module SidekiqScheduler
+  # Hook into *Sidekiq::Web* Sinatra app which adds a new "/recurring-jobs" page
+
+  module Web
+    VIEW_PATH = File.expand_path('../../../web/views', __FILE__)
+
+    def self.registered(app)
+      app.get '/recurring-jobs' do
+        @schedule = Sidekiq.schedule
+
+        erb File.read(File.join(VIEW_PATH, "recurring_jobs.erb"))
+      end
+    end
+  end
+end
+
+require 'sidekiq/web' unless defined?(Sidekiq::Web)
+Sidekiq::Web.register(SidekiqScheduler::Web)
+Sidekiq::Web.tabs["Recurring Jobs"] = "recurring-jobs"

--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -29,5 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest',    '~> 5.0'
   s.add_development_dependency 'mock_redis',  '~> 0'
   s.add_development_dependency 'simplecov',   '~> 0'
-
+  s.add_development_dependency 'rack-test'
+  s.add_development_dependency 'sinatra'
 end

--- a/test/lib/sidekiq/web_test.rb
+++ b/test/lib/sidekiq/web_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+require 'sidekiq-scheduler/web'
+require 'rack/test'
+
+class WebTest < MiniTest::Test
+  describe 'sidekiq-scheduler web' do
+    include Rack::Test::Methods
+
+    def app
+      Sidekiq::Web
+    end
+
+    before do
+      # Sidekiq::WebHelpers expects the Redis client to return an id
+      Sidekiq.redis { |conn| conn.client.stubs(:id).returns('redis://127.0.0.1:1234/0') }
+
+      Sidekiq.schedule = {
+        'Foo Job' => {
+          'class' => 'FooClass',
+          'cron' => '0 * * * * US/Eastern',
+          'args' => [42],
+          'description' => 'Does foo things.'
+        },
+
+        'Bar Job' => {
+          'class' => 'BarClass',
+          'every' => '1h',
+          'args' => ['foo', 'bar'],
+          'queue' => 'special'
+        }
+      }
+    end
+
+    it 'shows schedule' do
+      get '/recurring-jobs'
+
+      assert_match /Foo Job/, last_response.body
+      assert_match /FooClass/, last_response.body
+      assert_match /0 \* \* \* \* US\/Eastern/, last_response.body
+      assert_match /default/, last_response.body
+      assert_match /\[42\]/, last_response.body
+      assert_match /Does foo things\./, last_response.body
+
+      assert_match /Bar Job/, last_response.body
+      assert_match /BarClass/, last_response.body
+      assert_match /1h/, last_response.body
+      assert_match /special/, last_response.body
+      assert_match /\[\"foo\", \"bar\"\]/, last_response.body
+    end
+  end
+end

--- a/web/views/recurring_jobs.erb
+++ b/web/views/recurring_jobs.erb
@@ -1,0 +1,31 @@
+<h3>Recurring Jobs</h3>
+
+<div class="table_container">
+  <table class="table table-hover table-bordered table-striped table-white">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+        <th>Interval</th>
+        <th>Class</th>
+        <th>Queue</th>
+        <th>Arguments</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @schedule.each do |name, job_spec| %>
+        <tr>
+          <td><%= name %></td>
+          <td><%= job_spec['description'] %></td>
+          <td><%= job_spec.fetch 'cron', job_spec['every'] %></td>
+          <td><%= job_spec['class'] %></td>
+          <td>
+            <a href="<%= root_path %>queues/<%= job_spec.fetch('queue', 'default') %>"><%= job_spec.fetch('queue', 'default') %></a>
+          </td>
+          <td><%= job_spec['args'] %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
This adds a "Recurring Jobs" tab to the Sidekiq Web UI nav bar that links to a page with a table containing the current sidekiq-scheduler job schedule.

Inspired by resque-scheduler's resque-web UI integration.