### PR TITLE
Bump rufus scheduler version number.

### DIFF
--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'sidekiq',         '~> 3'
   s.add_dependency 'redis',           '~> 3'
-  s.add_dependency 'rufus-scheduler', '~> 3.1.7'
+  s.add_dependency 'rufus-scheduler', '~> 3.1.8'
   s.add_dependency 'multi_json',      '~> 1'
 
   s.add_development_dependency 'rake',        '~> 10.0'


### PR DESCRIPTION
3.1.8 includes bug fix for scheduler not running during hour long transition on DST in the Fall.