### PR TITLE
Update documentation page

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,8 @@
     <header itemscope="" itemtype="http://schema.org/Organization" class="Header">
       <div class="Header-wrapper"><a href="/" class="Header-logo"><img src="images/ss_logo.svg"></a>
         <nav class="Navbar">
-          <div class="Navbar-doc"><a href="https://github.com/Moove-it/sidekiq-scheduler" target="_blank">docs</a>
+          <div class="Navbar-doc">
+            <a href="http://www.rubydoc.info/github/moove-it/sidekiq-scheduler" target="_blank">docs</a>
           </div>
           <ul class="Navbar-list">
                 <li class="Navbar-listItem why-index"><a href="#why">why</a>
@@ -19,7 +20,8 @@
                 </li>
                 <li class="Navbar-listItem using-index"><a href="#using">using</a>
                 </li>
-                <li class="Navbar-listItem docs-index Navbar-listItem--doc"><a href="https://github.com/Moove-it/sidekiq-scheduler" target="_blank">docs</a>
+                <li class="Navbar-listItem docs-index Navbar-listItem--doc">
+                  <a href="http://www.rubydoc.info/github/moove-it/sidekiq-scheduler" target="_blank">docs</a>
                 </li>
           </ul>
         </nav>
@@ -43,7 +45,7 @@
         </div><a href="#why" class="SectionBrand-scroll"><i class="fa fa-chevron-down"></i></a>
       </div>
     </section>
-    <div class="fork-top"><a href="https://github.com/Moove-it/sidekiq-scheduler" target="_blank"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a></div>
+    <div class="fork-top"><a href="https://github.com/moove-it/sidekiq-scheduler" target="_blank"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a></div>
     <section id="why" class="SectionWay">
       <div class="container-cell">
         <div class="row">
@@ -59,7 +61,7 @@
                 </p>
                 <p class="SectionWay-description-paragraph-text">
                   To use it in a rails application, add to you Gemfile:
-                  gem 'sidekiq-scheduler', '~> 1’
+                  gem 'sidekiq-scheduler', '~> 2.0’
                   and the execute:
                   sidekiq
                 </p>


### PR DESCRIPTION
Update the documentation page links to go to rubydoc instead of github
and updated the example of the instalation to reflect the last version
change.