### PR TITLE
Remove old jobs when assigning schedule

### DIFF
--- a/lib/sidekiq-scheduler/schedule.rb
+++ b/lib/sidekiq-scheduler/schedule.rb
@@ -37,9 +37,14 @@ module SidekiqScheduler
     # param, otherwise params is passed in as the only parameter to perform.
     def schedule=(schedule_hash)
       schedule_hash = prepare_schedule(schedule_hash)
+      to_remove = (get_all_schedules || {}).keys - schedule_hash.keys
 
       schedule_hash.each do |name, job_spec|
         set_schedule(name, job_spec)
+      end
+
+      to_remove.each do |name|
+        remove_schedule(name)
       end
 
       @schedule = schedule_hash

--- a/test/schedule_test.rb
+++ b/test/schedule_test.rb
@@ -76,5 +76,22 @@ class ScheduleTest < Minitest::Test
       assert_equal nil, job_from_redis_without_decoding(job_id)
       assert Sidekiq.redis{ |r| r.sismember(:schedules_changed, job_id) }
     end
+
+    describe 'schedule update' do
+      let(:new_job_id)       { 'my_ivar_job_2' }
+      let(:new_job_class_id) { 'SomeIvarJob2' }
+
+      before do
+        Sidekiq::Scheduler.dynamic = true
+        Sidekiq.schedule = {job_id => cron_hash}
+      end
+
+      it 'schedule= adds new jobs to schedule and remove old ones' do
+        Sidekiq.schedule = {new_job_id => cron_hash}
+
+        assert_equal(cron_hash, job_from_redis(new_job_id))
+        assert_equal(nil, job_from_redis_without_decoding(job_id))
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi there,

I've been using sidekiq sheduler with Rails and I found it bit weird that when I remove a job from my yml file it doesn't get removed and you can still see it in web interface as well.

This fixes it. Let me know what you think!