### PR TITLE
Get rid of huge sleep in tests

### DIFF
--- a/test/lib/sidekiq/scheduler_test.rb
+++ b/test/lib/sidekiq/scheduler_test.rb
@@ -158,7 +158,8 @@ class ManagerTest < Minitest::Test
         }
       )
 
-      sleep(7)
+      Timecop.travel(7 * 60)
+      sleep 0.1
 
       assert Sidekiq::Scheduler.scheduled_jobs.include?('some_ivar_job')
       assert Sidekiq::Scheduler.scheduled_jobs.include?('some_ivar_job2')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,7 @@ require 'sidekiq-scheduler'
 require 'mocha/setup'
 require 'multi_json'
 require 'mock_redis'
+require 'timecop'
 
 require 'sidekiq'
 require 'sidekiq/util'


### PR DESCRIPTION
It's really pain in the ass to wait 7 seconds for tests to pass just because of single test. Timecop was already included in dependencies so I utilized it to refactor slow test.