### PR TITLE
Fix ActiveJob check

### DIFF
--- a/lib/sidekiq/scheduler.rb
+++ b/lib/sidekiq/scheduler.rb
@@ -140,7 +140,7 @@ module Sidekiq
       config['class'] = config['class'].constantize if config['class'].is_a?(String)
       config['args'] = Array(config['args'])
 
-      if defined?(ActiveJob) && config['class'].included_modules.include?(ActiveJob::Enqueuing)
+      if defined?(ActiveJob::Enqueuing) && config['class'].included_modules.include?(ActiveJob::Enqueuing)
         config['class'].new.enqueue(config)
       else
         Sidekiq::Client.push(config)


### PR DESCRIPTION
I was seeing a lot of this in my sidekiq logs:

```
NameError: uninitialized constant ActiveJob::Enqueuing
```

In a Rails, `ActiveJob` is defined even if `ActiveJob::Enqueuing` is not. `ActiveJob::Enqueuing` is only defined if you actually have a class that subclasses `ActiveJob::Base`. This just makes the `defined?` check more explicit. 