### PR TITLE
do not fail if the scheduled class is not a local class

### DIFF
--- a/lib/sidekiq/scheduler.rb
+++ b/lib/sidekiq/scheduler.rb
@@ -222,7 +222,7 @@ module Sidekiq
     #
     # @return [Boolean]
     def self.active_job_enqueue?(klass)
-      defined?(ActiveJob::Enqueuing) && klass.included_modules.include?(ActiveJob::Enqueuing)
+      defined?(ActiveJob::Enqueuing) && klass.is_a?(Class) && klass.included_modules.include?(ActiveJob::Enqueuing)
     end
 
     # Convert the given arguments in the format expected to be enqueued.
@@ -234,7 +234,9 @@ module Sidekiq
     #
     # @return [Hash]
     def self.prepare_arguments(config)
-      config['class'] = config['class'].constantize if config['class'].is_a?(String)
+      if config['class'].is_a?(String) && Object.const_defined?(config['class'])
+        config['class'] = Object.const_get(config['class'])
+      end
 
       if config['args'].is_a?(Hash)
         config['args'].symbolize_keys! if config['args'].respond_to?(:symbolize_keys!)

--- a/spec/sidekiq/scheduler_spec.rb
+++ b/spec/sidekiq/scheduler_spec.rb
@@ -40,8 +40,29 @@ describe Sidekiq::Scheduler do
         'args'  => '/tmp'
       }
 
-      expect(Sidekiq::Client).to receive(:push).with(process_parameters(config))
+      expect(Sidekiq::Client).to receive(:push) do |opts|
+        expect(opts['class']).to eq(SomeWorker)
+        expect(opts['args']).to eq(['/tmp'])
+      end
 
+      Sidekiq::Scheduler.enqueue_job(config)
+    end
+
+    it 'enqueue does not fail if it cannot constantize' do
+      # The job should be loaded, since a missing rails_env means ALL envs.
+      ENV['RAILS_ENV'] = 'production'
+
+      config = {
+        'cron'  => '* * * * *',
+        'class' => 'SomeOtherWorker',
+        'queue' => 'high',
+        'args'  => '/tmp'
+      }
+
+      expect(Sidekiq::Client).to receive(:push) do |opts|
+        expect(opts['class']).to eq('SomeOtherWorker')
+        expect(opts['args']).to eq(['/tmp'])
+      end
       Sidekiq::Scheduler.enqueue_job(config)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,17 +25,4 @@ RSpec.configure do |config|
   config.profile_examples = 10
 
   config.order = :random
-
-  def process_parameters(config)
-    config['class'] = config['class'].constantize if config['class'].is_a?(String)
-
-    if config['args'].is_a?(Hash)
-      config['args'].symbolize_keys! if config['args'].respond_to?(:symbolize_keys!)
-    else
-      config['args'] = Array(config['args'])
-    end
-
-    config
-  end
-
 end


### PR DESCRIPTION
right now, if a class is not in the local path, it cannot be scheduled.

This is not ideal where the scheduler and job are not in the same
project (or where project 1 can enqueue a job that is processed by
project 2)