### PR TITLE
Prevent enqueueing of duplicated  `cron` and `at` job instances

### DIFF
--- a/lib/sidekiq/scheduler.rb
+++ b/lib/sidekiq/scheduler.rb
@@ -7,6 +7,8 @@ module Sidekiq
   class Scheduler
     extend Sidekiq::Util
 
+    REGISTERED_JOBS_THRESHOLD_IN_SECONDS = 24 * 60 * 60
+
     # We expect rufus jobs to have #params
     Rufus::Scheduler::Job.module_eval do
 
@@ -102,16 +104,19 @@ module Sidekiq
         interval_defined = false
         interval_types = %w{cron every at in}
         interval_types.each do |interval_type|
-          if !config[interval_type].nil? && config[interval_type].length > 0
-            args = self.optionizate_interval_value(config[interval_type])
+          config_interval_type = config[interval_type]
+
+          if !config_interval_type.nil? && config_interval_type.length > 0
+
+            args = self.optionizate_interval_value(config_interval_type)
 
             # We want rufus_scheduler to return a job object, not a job id
             opts = { :job => true }
 
-            @@scheduled_jobs[name] = self.rufus_scheduler.send(interval_type, *args, opts) do
-              logger.info "queueing #{config['class']} (#{name})"
+            @@scheduled_jobs[name] = self.rufus_scheduler.send(interval_type, *args, opts) do |job, time|
               config.delete(interval_type)
-              self.handle_errors { self.enqueue_job(config) }
+
+              idempotent_job_enqueue(name, time, config)
             end
 
             interval_defined = true
@@ -123,6 +128,25 @@ module Sidekiq
         unless interval_defined
           logger.info "no #{interval_types.join(' / ')} found for #{config['class']} (#{name}) - skipping"
         end
+      end
+    end
+
+    # Pushes the job into Sidekiq if not already pushed for the given time
+    #
+    # @param [String] job_name The job's name
+    # @param [Time] time The time when the job got cleared for triggering
+    # @param [Hash] config Job's config hash
+    def self.idempotent_job_enqueue(job_name, time, config)
+      registered = register_job_instance(job_name, time)
+
+      if registered
+        logger.info "queueing #{config['class']} (#{job_name})"
+
+        self.handle_errors { self.enqueue_job(config) }
+
+        remove_elder_job_instances(job_name)
+      else
+        logger.debug { "Ignoring #{job_name} job as it has been already enqueued" }
       end
     end
 
@@ -263,5 +287,38 @@ module Sidekiq
       queues.empty? || queues.include?(job_queue)
     end
 
+    # Registers a queued job instance
+    #
+    # @param [String] job_name The job's name
+    # @param [Time] time Time at which the job was cleared by the scheduler
+    #
+    # @return [Boolean] true if the job was registered, false when otherwise
+    def self.register_job_instance(job_name, time)
+      pushed_job_key = pushed_job_key(job_name)
+
+      registered, _ = Sidekiq.redis do |r|
+        r.pipelined do
+          r.zadd(pushed_job_key, time.to_i, time.to_i)
+          r.expire(pushed_job_key, REGISTERED_JOBS_THRESHOLD_IN_SECONDS)
+        end
+      end
+
+      registered
+    end
+
+    def self.remove_elder_job_instances(job_name)
+      Sidekiq.redis do |r|
+        r.zremrangebyscore(pushed_job_key(job_name), 0, Time.now.to_i - REGISTERED_JOBS_THRESHOLD_IN_SECONDS)
+      end
+    end
+
+    # Returns the key of the Redis sorted set used to store job enqueues
+    #
+    # @param [String] job_name The name of the job
+    #
+    # @return [String]
+    def self.pushed_job_key(job_name)
+      "sidekiq-scheduler:pushed:#{job_name}"
+    end
   end
 end

--- a/spec/sidekiq/scheduler_spec.rb
+++ b/spec/sidekiq/scheduler_spec.rb
@@ -4,11 +4,11 @@ describe Sidekiq::Scheduler do
     Sidekiq::Scheduler.enabled = true
     Sidekiq::Scheduler.dynamic = false
     Sidekiq::Scheduler.listened_queues_only = false
-    Sidekiq.redis { |r| r.del(:schedules) }
-    Sidekiq.redis { |r| r.del(:schedules_changed) }
+    Sidekiq.redis(&:flushall)
     Sidekiq.options[:queues] = Sidekiq::DEFAULTS[:queues]
     Sidekiq::Scheduler.clear_schedule!
     Sidekiq::Scheduler.send(:class_variable_set, :@@scheduled_jobs, {})
+    Sidekiq::Worker.clear_all
   end
 
   it 'sidekiq-scheduler enabled option is working' do
@@ -349,6 +349,78 @@ describe Sidekiq::Scheduler do
     end
   end
 
+  describe '.idempotent_job_enqueue' do
+    def enqueued_jobs_registry
+      Sidekiq.redis { |r| r.zrange(pushed_job_key, 0, -1) }
+    end
+
+    let(:config) { JobConfigurationsFaker.some_worker }
+
+    let(:job_name) { 'some-worker' }
+
+    let(:pushed_job_key) { Sidekiq::Scheduler.pushed_job_key(job_name) }
+
+    before do
+      Sidekiq.redis { |r| r.del(pushed_job_key) }
+    end
+
+    let(:time) { Time.now }
+
+    it 'enqueues a job' do
+      expect {
+        Sidekiq::Scheduler.idempotent_job_enqueue(job_name, time, config)
+      }.to change { Sidekiq::Queues[config['queue']].size }.by(1)
+    end
+
+    it 'registers the enqueued job' do
+      expect {
+        Sidekiq::Scheduler.idempotent_job_enqueue(job_name, time, config)
+      }.to change { enqueued_jobs_registry.last == time.to_i.to_s }.from(false).to(true)
+    end
+
+    context 'when elder enqueued jobs' do
+      let(:some_time_ago) { time - Sidekiq::Scheduler::REGISTERED_JOBS_THRESHOLD_IN_SECONDS }
+
+      let(:near_time_ago) { time - Sidekiq::Scheduler::REGISTERED_JOBS_THRESHOLD_IN_SECONDS  / 2 }
+
+      before  do
+        Timecop.freeze(some_time_ago) do
+          Sidekiq::Scheduler.register_job_instance(job_name, some_time_ago)
+        end
+
+        Timecop.freeze(near_time_ago) do
+          Sidekiq::Scheduler.register_job_instance(job_name, near_time_ago)
+        end
+      end
+
+      it 'deregisters elder enqueued jobs' do
+        expect {
+          Sidekiq::Scheduler.idempotent_job_enqueue(job_name, time, config)
+        }.to change { enqueued_jobs_registry.first == some_time_ago.to_i.to_s }.from(true).to(false)
+      end
+    end
+
+    context 'when the job has been previously enqueued' do
+      before { Sidekiq::Scheduler.idempotent_job_enqueue(job_name, time, config) }
+
+      it 'is not enqueued again' do
+        expect {
+          Sidekiq::Scheduler.idempotent_job_enqueue(job_name, time, config)
+        }.to_not change { Sidekiq::Queues[config['queue']].size }
+      end
+    end
+
+    context 'when it was enqueued for a different Time' do
+      before { Sidekiq::Scheduler.idempotent_job_enqueue(job_name, time - 1, config) }
+
+      it 'is enqueued again' do
+        expect {
+          Sidekiq::Scheduler.idempotent_job_enqueue(job_name, time, config)
+        }.to change { Sidekiq::Queues[config['queue']].size }.by(1)
+      end
+    end
+  end
+
   describe '.update_schedule' do
     it 'loads a new job' do
       Sidekiq::Scheduler.dynamic = true
@@ -451,6 +523,16 @@ describe Sidekiq::Scheduler do
     end
   end
 
+  describe '.enque_with_sidekiq' do
+    let(:config) { JobConfigurationsFaker.some_worker }
+
+    it 'enqueues a job into a sidekiq queue' do
+      expect {
+        Sidekiq::Scheduler.enque_with_sidekiq(config)
+      }.to change { Sidekiq::Queues[config['queue']].size }.by(1)
+    end
+  end
+
   describe '.initialize_active_job' do
     describe 'when the object has no arguments' do
       it 'should be correctly initialized' do
@@ -483,4 +565,41 @@ describe Sidekiq::Scheduler do
     end
   end
 
+  describe '.register_job_instance' do
+    let(:job_name) { 'some-worker' }
+
+    let(:pushed_job_key) { Sidekiq::Scheduler.pushed_job_key(job_name) }
+
+    let(:now) { Time.now }
+
+    it { expect(Sidekiq::Scheduler.register_job_instance(job_name, now)).to be true }
+
+    it 'stores the job instance into Redis' do
+      expect {
+        Sidekiq::Scheduler.register_job_instance(job_name, now)
+      }.to change { Sidekiq.redis { |r| r.zcard(pushed_job_key) } }.by(1)
+    end
+
+    it 'persists a expirable key' do
+      Sidekiq::Scheduler.register_job_instance(job_name, now)
+
+      Timecop.travel(Sidekiq::Scheduler::REGISTERED_JOBS_THRESHOLD_IN_SECONDS) do
+        expect(Sidekiq.redis { |r| r.exists(pushed_job_key) }).to be false
+      end
+    end
+
+    context 'when job has been previously registered' do
+      before { Sidekiq::Scheduler.register_job_instance(job_name, now) }
+
+      it { expect(Sidekiq::Scheduler.register_job_instance(job_name, now)).to be false }
+
+      context 'but with different timestamp' do
+        let(:another_timestamp) { now + 1 }
+
+        it 'is true' do
+          expect(Sidekiq::Scheduler.register_job_instance(job_name, another_timestamp)).to be true
+        end
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ SimpleCov.start
 Coveralls.wear!
 
 require 'sidekiq'
+require 'sidekiq/testing'
 require 'sidekiq-scheduler'
 require 'multi_json'
 require 'timecop'

--- a/spec/support/faker/job_configurations.rb
+++ b/spec/support/faker/job_configurations.rb
@@ -1,0 +1,11 @@
+class JobConfigurationsFaker
+
+  def self.some_worker(options = {})
+    {
+      'class' => 'SomeWorker',
+      'queue' => 'low',
+      'args' => []
+    }.merge(options)
+  end
+
+end


### PR DESCRIPTION
Ignore job enqueueing if it has already been enqueued for the same timestamp. 

This solves the problem when multiple sidekiq instances having cron jobs are running.

Issue: #88 