### PR TITLE
Change web ui to be compatible with Sidekiq 4.2.0

### DIFF
--- a/lib/sidekiq-scheduler/job_presenter.rb
+++ b/lib/sidekiq-scheduler/job_presenter.rb
@@ -1,4 +1,8 @@
-require 'sidekiq/web_helpers'
+begin
+  require 'sidekiq/web/helpers'
+rescue LoadError
+  require 'sidekiq/web_helpers'
+end
 
 module SidekiqScheduler
   class JobPresenter

--- a/lib/sidekiq-scheduler/web.rb
+++ b/lib/sidekiq-scheduler/web.rb
@@ -16,7 +16,7 @@ module SidekiqScheduler
       app.get '/recurring-jobs/:name/enqueue' do
         schedule = Sidekiq.get_schedule(params[:name])
         Sidekiq::Scheduler.enqueue_job(schedule)
-        redirect to('/recurring-jobs')
+        redirect '/recurring-jobs'
       end
     end
   end
@@ -25,4 +25,4 @@ end
 require 'sidekiq/web' unless defined?(Sidekiq::Web)
 Sidekiq::Web.register(SidekiqScheduler::Web)
 Sidekiq::Web.tabs['recurring_jobs'] = 'recurring-jobs'
-Sidekiq::Web.set :locales, Sidekiq::Web.locales << File.expand_path(File.dirname(__FILE__) + "/../../web/locales")
+Sidekiq::Web.locales << File.expand_path(File.dirname(__FILE__) + "/../../web/locales")


### PR DESCRIPTION
Sidekiq 4.2.0 migrated  its web app from Sinatra to a plain Rack app, so some
tweaks are needed to support both approaches.