### PR TITLE
Follow sidekiq redirect pattern for 'Enqueue Now' button

### DIFF
--- a/lib/sidekiq-scheduler/web.rb
+++ b/lib/sidekiq-scheduler/web.rb
@@ -16,7 +16,7 @@ module SidekiqScheduler
       app.get '/recurring-jobs/:name/enqueue' do
         schedule = Sidekiq.get_schedule(params[:name])
         Sidekiq::Scheduler.enqueue_job(schedule)
-        redirect '/recurring-jobs'
+        redirect "#{root_path}recurring-jobs"
       end
     end
   end


### PR DESCRIPTION
Clicking the ‘Enqueue Now’ button redirects to ‘/recurring-jobs’ rather
than `{sidekiq-route-namespace}/recurring-jobs’. This follows the
pattern in Sidekiq’s own classes to achieve correct routing