### PR TITLE
Stringify configs

### DIFF
--- a/lib/sidekiq-scheduler.rb
+++ b/lib/sidekiq-scheduler.rb
@@ -21,7 +21,7 @@ Sidekiq.configure_server do |config|
     scheduler_options = {
       dynamic:   dynamic,
       enabled:   enabled,
-      schedule:  config.options.fetch(:schedule, nil),
+      schedule:  config.options.fetch(:schedule, nil).deep_stringify_keys,
       listened_queues_only: listened_queues_only
     }
 

--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rufus-scheduler', '~> 3.1.8'
   s.add_dependency 'multi_json',      '~> 1'
   s.add_dependency 'tilt',            '>= 1.4.0'
+  s.add_dependency 'activesupport',   '~> 5.0'
 
   s.add_development_dependency 'rake',                    '~> 10.0'
   s.add_development_dependency 'timecop',                 '~> 0'


### PR DESCRIPTION
currently sidekiq expects symbols in their yml file. chef cookbooks also expect this format and converts it to match. example chef cookbook that currently matches this behaviour https://supermarket.chef.io/cookbooks/opsworks_ruby

However, sidekiq-scheduler only expects the highest level :schedule: and the rest of the config is read through strings. this fix ensures that using sidekiq format also works, and the current chef cookbooks will also work.