### PR TITLE
add hash with indifferent access

### DIFF
--- a/lib/sidekiq-scheduler/schedule.rb
+++ b/lib/sidekiq-scheduler/schedule.rb
@@ -117,7 +117,7 @@ module SidekiqScheduler
     private
 
     def prepare_schedule(schedule_hash)
-      prepared_hash = {}
+      prepared_hash = HashWithIndifferentAccess.new
       schedule_hash.each do |name, job_spec|
         job_spec = job_spec.dup
         job_spec['class'] = name unless job_spec.key?('class') || job_spec.key?(:class)

--- a/lib/sidekiq/scheduler.rb
+++ b/lib/sidekiq/scheduler.rb
@@ -60,7 +60,7 @@ module Sidekiq
           logger.info 'Schedule empty! Set Sidekiq.schedule' if Sidekiq.schedule.empty?
 
 
-          @@scheduled_jobs = {}
+          @@scheduled_jobs = HashWithIndifferentAccess.new
 
           Sidekiq.schedule.each do |name, config|
             if !listened_queues_only || enabled_queue?(config['queue'])

--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rufus-scheduler', '~> 3.1.8'
   s.add_dependency 'multi_json',      '~> 1'
   s.add_dependency 'tilt',            '>= 1.4.0'
+  s.add_dependency 'hashwithindifferentaccess'
 
   s.add_development_dependency 'rake',                    '~> 10.0'
   s.add_development_dependency 'timecop',                 '~> 0'

--- a/spec/sidekiq-scheduler/manager_spec.rb
+++ b/spec/sidekiq-scheduler/manager_spec.rb
@@ -12,7 +12,7 @@ describe SidekiqScheduler::Manager do
         enabled: true,
         dynamic: true,
         listened_queues_only: true,
-        schedule: { current: ScheduleFaker.cron_schedule( class: 'CurrentJob') }
+        schedule: { current: ScheduleFaker.cron_schedule( 'class' => 'CurrentJob') }
       }
     end
 


### PR DESCRIPTION
referencing [issue #135](https://github.com/moove-it/sidekiq-scheduler/issues/135)
This gem is just the hash ext from active support and nothing else.

It adds the least amount of 3rd party code, and does it nicely.

The one test was modified cause it was basically pushing a new key to the options hash rather than replacing the existing key. This is one of those problems with adding a symbol key to a hash with string keys. But with hashwithindifferent access, that problem goes away cause the keys are treated as if they were the same.

This also allows the yml configs to be symbols or strings.