### PR TITLE
Set schedule if it was not previously set

### DIFF
--- a/lib/sidekiq-scheduler.rb
+++ b/lib/sidekiq-scheduler.rb
@@ -18,10 +18,13 @@ Sidekiq.configure_server do |config|
     listened_queues_only = Sidekiq::Scheduler.listened_queues_only
     listened_queues_only = listened_queues_only.nil? ? scheduler[:listened_queues_only] : listened_queues_only
 
+    schedule = Sidekiq.schedule
+    schedule ||= config.options[:schedule] || {}
+
     scheduler_options = {
       dynamic:   dynamic,
       enabled:   enabled,
-      schedule:  config.options.fetch(:schedule, nil),
+      schedule:  schedule,
       listened_queues_only: listened_queues_only
     }
 

--- a/lib/sidekiq-scheduler/manager.rb
+++ b/lib/sidekiq-scheduler/manager.rb
@@ -18,7 +18,7 @@ module SidekiqScheduler
       Sidekiq::Scheduler.enabled = options[:enabled]
       Sidekiq::Scheduler.dynamic = options[:dynamic]
       Sidekiq::Scheduler.listened_queues_only = options[:listened_queues_only]
-      Sidekiq.schedule = options[:schedule] || {}
+      Sidekiq.schedule = options[:schedule]
     end
 
     def stop

--- a/lib/sidekiq-scheduler/schedule.rb
+++ b/lib/sidekiq-scheduler/schedule.rb
@@ -38,7 +38,7 @@ module SidekiqScheduler
     # param, otherwise params is passed in as the only parameter to perform.
     def schedule=(schedule_hash)
       schedule_hash = prepare_schedule(schedule_hash)
-      to_remove = (get_all_schedules || {}).keys - schedule_hash.keys.map(&:to_s)
+      to_remove = get_all_schedules.keys - schedule_hash.keys.map(&:to_s)
 
       schedule_hash.each do |name, job_spec|
         set_schedule(name, job_spec)
@@ -52,7 +52,7 @@ module SidekiqScheduler
     end
 
     def schedule
-      @schedule ||= {}
+      @schedule
     end
 
     # Reloads the schedule from Redis and return it.
@@ -77,10 +77,9 @@ module SidekiqScheduler
 
     # gets the schedule as it exists in redis
     def get_all_schedules
-      schedules = nil
-      if Sidekiq.redis { |r| r.exists(:schedules) }
-        schedules = {}
+      schedules = {}
 
+      if Sidekiq.redis { |r| r.exists(:schedules) }
         Sidekiq.redis { |r| r.hgetall(:schedules) }.tap do |h|
           h.each do |name, config|
             schedules[name] = JSON(config)

--- a/spec/sidekiq-scheduler/manager_spec.rb
+++ b/spec/sidekiq-scheduler/manager_spec.rb
@@ -48,17 +48,5 @@ describe SidekiqScheduler::Manager do
         subject
       }.to change { Sidekiq.schedule }.to(options[:schedule])
     end
-
-    context 'when no :schedule option' do
-      before do
-        options.delete(:schedule)
-      end
-
-      it 'deletes the previous jobs' do
-        expect {
-          subject
-        }.to change { Sidekiq.schedule }.to({})
-      end
-    end
   end
 end

--- a/spec/sidekiq-scheduler/schedule_spec.rb
+++ b/spec/sidekiq-scheduler/schedule_spec.rb
@@ -96,10 +96,8 @@ describe SidekiqScheduler::Schedule do
   describe '.get_schedule' do
     subject { Sidekiq.get_schedule(job_id) }
 
-    context 'when schedules previously set' do
-      before do
-        Sidekiq.set_schedule(job_id, cron_hash)
-      end
+    context 'when schedules are previously set' do
+      before { Sidekiq.set_schedule(job_id, cron_hash) }
 
       it { should eq(job_from_redis(job_id)) }
 

--- a/spec/sidekiq-scheduler/schedule_spec.rb
+++ b/spec/sidekiq-scheduler/schedule_spec.rb
@@ -94,12 +94,30 @@ describe SidekiqScheduler::Schedule do
   end
 
   describe '.get_schedule' do
-    it 'returns a schedule' do
-      Sidekiq.set_schedule(job_id, cron_hash)
+    subject { Sidekiq.get_schedule(job_id) }
 
-      schedule = Sidekiq.get_schedule(job_id)
+    context 'when schedules previously set' do
+      before do
+        Sidekiq.set_schedule(job_id, cron_hash)
+      end
 
-      expect(schedule).to eq(job_from_redis(job_id))
+      it { should eq(job_from_redis(job_id)) }
+
+      context 'when name is not given' do
+        subject { Sidekiq.get_schedule }
+
+        it { should include(job_id => job_from_redis(job_id)) }
+      end
+    end
+
+    context 'when no schedules previously set' do
+      it { should be_nil }
+
+      context 'when name is not given' do
+        subject { Sidekiq.get_schedule }
+
+        it { should eq({}) }
+      end
     end
   end
 
@@ -113,5 +131,4 @@ describe SidekiqScheduler::Schedule do
       expect(changed_job?(job_id)).to be_truthy
     end
   end
-
 end


### PR DESCRIPTION
On startup sidekiq hook, set the schedule if it was not previously set,
following the same mechanism as other configuration flags.