### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ You can provide options to `every` or `cron` via an Array:
 
 ``` yaml
   clear_leaderboards_moderator:
-    every: ["30s", :first_in => '120s']
+    every: ["30s", first_in: '120s']
     class: CheckDaemon
     queue: low
     description: "This job will check Daemon every 30 seconds after 120 seconds after start"


### PR DESCRIPTION
Psych is unable to parse the old format of :first_in => throwing an exception on startup of

```
(<unknown>): did not find expected node content while parsing a flow node at line 11 column 20
/lib/ruby/2.3.0/psych.rb:377:in `parse'
/lib/ruby/2.3.0/psych.rb:377:in `parse_stream'
/lib/ruby/2.3.0/psych.rb:325:in `parse'
/lib/ruby/2.3.0/psych.rb:252:in `load'
/lib/ruby/gems/2.3.0/gems/sidekiq-4.2.5/lib/sidekiq/cli.rb:375:in `parse_config'
/lib/ruby/gems/2.3.0/gems/sidekiq-4.2.5/lib/sidekiq/cli.rb:208:in `setup_options'
/lib/ruby/gems/2.3.0/gems/sidekiq-4.2.5/lib/sidekiq/cli.rb:39:in `parse'
/lib/ruby/gems/2.3.0/gems/sidekiq-4.2.5/bin/sidekiq:11:in `<top (required)>'
/bin/sidekiq:23:in `load'
/bin/sidekiq:23:in `<top (required)>'
```

If you use the modern JSON style format for hashes then everything parses correctly.