### PR TITLE
change min rufus-scheduler dep to ~> 3.2

### DIFF
--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'hashie',          '~> 3.4'
   s.add_dependency 'sidekiq',         '>= 3'
   s.add_dependency 'redis',           '~> 3'
-  s.add_dependency 'rufus-scheduler', '~> 3.1.8'
+  s.add_dependency 'rufus-scheduler', '~> 3.2'
   s.add_dependency 'tilt',            '>= 1.4.0'
 
   s.add_development_dependency 'rake',                    '~> 10.0'


### PR DESCRIPTION
Firstly thanks for your work on this project!

We're starting the process of moving from resque to sidekiq and will be running the two side-by-side while we complete the transition.

resque-scheduler has a rufus-scheduler dependency on `~> 3.2`  while sidekiq-scheduler currently has `~> 3.1.8`. Would you be happy to bump or relax the version constraints?

https://github.com/resque/resque-scheduler/blob/master/resque-scheduler.gemspec#L59

https://github.com/jmettraux/rufus-scheduler/compare/v3.1.8...v3.2.0?expand=1