### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ require 'sidekiq/scheduler'
 
 Sidekiq.configure_server do |config|
   config.on(:startup) do
-    Sidekiq.schedule = YAML.load_file(File.expand_path('../../sidekiq_scheduler.yml', __FILE__))
+    Sidekiq.schedule = YAML.load_file(File.expand_path('../../scheduler.yml', __FILE__))
     Sidekiq::Scheduler.reload_schedule!
   end
 end


### PR DESCRIPTION
In the 'Loading the schedule' section it was assumed the schedule filed was named 'scheduler.yml', but the initializer was set to load 'sidekiq_scheduler.yml'.