### PR TITLE
Infer queue name when loading schedule

### DIFF
--- a/spec/sidekiq-scheduler/manager_spec.rb
+++ b/spec/sidekiq-scheduler/manager_spec.rb
@@ -12,7 +12,7 @@ describe SidekiqScheduler::Manager do
         enabled: true,
         dynamic: true,
         listened_queues_only: true,
-        schedule: { 'current' => ScheduleFaker.cron_schedule }
+        schedule: { 'current' => ScheduleFaker.cron_schedule('queue' => 'default') }
       }
     end
 

--- a/spec/support/workers/email_sender.rb
+++ b/spec/support/workers/email_sender.rb
@@ -1,6 +1,7 @@
 require 'active_job'
 
 class EmailSender < ActiveJob::Base
+  queue_as :email
 
   def perform
   end


### PR DESCRIPTION
Fixes https://github.com/moove-it/sidekiq-scheduler/issues/157

This change updates the `SidekiqScheduler::Schedule#schedule=` to
infer queue name from the worker. It supports both sidekiq workers
and active jobs by checking for `sidekiq_options` and a `queue_name`.

Note: This change does not update the `set_schedule` method to infer
the queue name but could be updated to handle this case if required.