### PR TITLE
Fix error JSON::ParserError: lexical error: invalid char in json text on schedule loading

### DIFF
--- a/lib/sidekiq-scheduler/schedule.rb
+++ b/lib/sidekiq-scheduler/schedule.rb
@@ -102,7 +102,7 @@ module SidekiqScheduler
     def set_schedule(name, config)
       existing_config = get_schedule(name)
       unless existing_config && existing_config == config
-        Sidekiq.redis { |r| r.hset(:schedules, name, JSON(config)) }
+        Sidekiq.redis { |r| r.hset(:schedules, name, JSON.generate(config)) }
         Sidekiq.redis { |r| r.sadd(:schedules_changed, name) }
       end
       config


### PR DESCRIPTION
We send `hash` as param into `set_schedule`, not json (string). In this case `JSON(hash)` raised exception (`JSON::ParserError: lexical error: invalid char in json text.`) and we do not need parse this arg.