### PR TITLE
Fix 'next time' when schedule includes options

### DIFF
--- a/lib/sidekiq-scheduler/rufus_utils.rb
+++ b/lib/sidekiq-scheduler/rufus_utils.rb
@@ -1,0 +1,29 @@
+require 'hashie'
+
+module SidekiqScheduler
+  class RufusUtils
+
+    # Normalizes schedule options to rufust scheduler options
+    #
+    # @param options [String, [Array]
+    #
+    # @return [Array]
+    #
+    # @example
+    #   normalize_schedule_options('15m') => ['12d', {}]
+    #   normalize_schedule_options(['15m']) => ['12d', {}]
+    #   normalize_schedule_options(['15m', first_in: '5m']) => ['12d', { first_in: '5m' }]
+    def self.normalize_schedule_options(options)
+      schedule, opts = options
+
+      if !opts.is_a?(Hash)
+        opts = {}
+      end
+
+      opts = Hashie.symbolize_keys(opts)
+
+      return schedule, opts
+    end
+  end
+end
+

--- a/lib/sidekiq-scheduler/rufus_utils.rb
+++ b/lib/sidekiq-scheduler/rufus_utils.rb
@@ -10,9 +10,9 @@ module SidekiqScheduler
     # @return [Array]
     #
     # @example
-    #   normalize_schedule_options('15m') => ['12d', {}]
-    #   normalize_schedule_options(['15m']) => ['12d', {}]
-    #   normalize_schedule_options(['15m', first_in: '5m']) => ['12d', { first_in: '5m' }]
+    #   normalize_schedule_options('15m') => ['15m', {}]
+    #   normalize_schedule_options(['15m']) => ['15m', {}]
+    #   normalize_schedule_options(['15m', first_in: '5m']) => ['15m', { first_in: '5m' }]
     def self.normalize_schedule_options(options)
       schedule, opts = options
 

--- a/spec/sidekiq-scheduler/rufus_utils_spec.rb
+++ b/spec/sidekiq-scheduler/rufus_utils_spec.rb
@@ -1,0 +1,61 @@
+describe SidekiqScheduler::RufusUtils do
+  subject(:utils) { described_class }
+
+  describe '.normalize_schedule_options' do
+    context 'with schedule only' do
+      let(:args) { '10s' }
+
+      it 'returns the schedule and empty options' do
+        schedule, opts = utils.normalize_schedule_options(args)
+
+        expect(schedule).to eq('10s')
+        expect(opts).to eq({})
+      end
+    end
+
+    context 'with schedule being contained in an array' do
+      let(:args) { ['10s'] }
+
+      it 'returns the schedule and empty options' do
+        schedule, opts = utils.normalize_schedule_options(args)
+
+        expect(schedule).to eq('10s')
+        expect(opts).to eq({})
+      end
+    end
+
+    context 'with schedule only and options' do
+      let(:args) { utils.normalize_schedule_options(['10s', first_in: '5m']) }
+
+      it 'returns both of them' do
+        schedule, opts = utils.normalize_schedule_options(args)
+
+        expect(schedule).to eq('10s')
+        expect(opts).to include(first_in: '5m')
+      end
+    end
+
+    context 'with extra options' do
+      let(:args) { ['10s', { first_in: '5m' }, { tag: 'test' }] }
+
+      it 'ignores them' do
+        schedule, opts, extra = utils.normalize_schedule_options(args);
+
+        expect(schedule).to eq('10s')
+        expect(opts).to include(first_in: '5m')
+        expect(extra).to be_nil
+      end
+    end
+
+    context 'with options not being a Hash' do
+      let(:args) { ['10s', true] }
+
+      it 'returns an empty options hash' do
+        schedule, opts = utils.normalize_schedule_options(args)
+
+        expect(schedule).to eq('10s')
+        expect(opts).to eq({})
+      end
+    end
+  end
+end

--- a/spec/sidekiq/scheduler_spec.rb
+++ b/spec/sidekiq/scheduler_spec.rb
@@ -284,8 +284,8 @@ describe Sidekiq::Scheduler do
       expect {
         Sidekiq.set_schedule('other_job', ScheduleFaker.cron_schedule({'args' => 'sample'}))
 
-        Timecop.travel(7 * 60)
-        sleep 0.1
+        Timecop.travel(6 * 60)
+        sleep 0.5
       }.to change { Sidekiq::Scheduler.scheduled_jobs.include?('other_job') }.to(true)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,10 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
 
+  config.after(:each) do
+    Timecop.return
+  end
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end


### PR DESCRIPTION
Display right 'next time' values in Web UI

When options in form of array were passed to the schedule config, 'next time' column
was not being updated.

Schedule configuration sample causing the bug:

```yaml
:schedule:
  hello_world:
    every: ['30s', first_in: '120s']
    class: HelloWorld
```