### PR TITLE
Add ability to pass metadata to worker method

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ The schedule is configured through the `:schedule` config entry in the sidekiq c
     args: ['*.pdf']
     description: "This job queues pdf content for indexing in solr"
 
+    # Enable the `metadata` argument which will pass a Hash containing the schedule metadata
+    # as the last argument of the `perform` method. `false` by default.
+    include_metadata: true
+
     # Enable / disable a job. All jobs are enabled by default.
     enabled: true
 ```

--- a/README.md
+++ b/README.md
@@ -125,6 +125,34 @@ The schedule is configured through the `:schedule` config entry in the sidekiq c
     enabled: true
 ```
 
+### Schedule metadata
+You can configure Sidekiq-scheduler to pass an argument with metadata about the scheduling process
+to the worker's `perform` method.
+
+In the configuration file add the following on each worker class entry:
+
+```yaml
+
+  SampleWorker:
+    include_metadata: true
+```
+
+On your `perform` method, expect an additional argument:
+
+```ruby
+  def perform(args, ..., metadata)
+    # Do something with the metadata
+  end
+```
+
+The `metadata` hash contains the following keys:
+
+```ruby
+  metadata.keys =>
+    [
+      :scheduled_at # The epoch when the job was scheduled to run
+    ]
+```
 
 ## Schedule types
 

--- a/lib/sidekiq/scheduler.rb
+++ b/lib/sidekiq/scheduler.rb
@@ -124,7 +124,7 @@ module Sidekiq
         if registered
           logger.info "queueing #{config['class']} (#{job_name})"
 
-          handle_errors { enqueue_job(config) }
+          handle_errors { enqueue_job(config, time) }
 
           remove_elder_job_instances(job_name)
         else
@@ -157,12 +157,14 @@ module Sidekiq
       end
 
       # Enqueue a job based on a config hash
-      def enqueue_job(job_config)
+      #
+      # @param job_config [Hash] the job configuration
+      # @param time [Time] time the job is enqueued
+      def enqueue_job(job_config, time=Time.now)
         config = prepare_arguments(job_config.dup)
 
-        if config['include_metadata']
-          config['args'] = arguments_with_metadata(config['args'].dup)
-          config.delete('include_metadata')
+        if config.delete('include_metadata')
+          config['args'] = arguments_with_metadata(config['args'], scheduled_at: time.to_f)
         end
 
         if active_job_enqueue?(config['class'])
@@ -228,7 +230,8 @@ module Sidekiq
       end
 
       def enqueue_with_active_job(config)
-        initialize_active_job(config['class'], config['args']).enqueue(config)
+        # TODO Does ActiveJob really need to get the config data in the `enqueue` call?
+        initialize_active_job(config['class'], config['args']).enqueue(sanitize_job_config(config))
       end
 
       def enqueue_with_sidekiq(config)
@@ -391,21 +394,22 @@ module Sidekiq
       end
 
       # Adds a Hash with schedule metadata as the last argument to call the worker.
-      # @example when parameter is an array
-      #   arguments_with_metadata(['arg1']) #=> ['arg1', {:scheduled_at => 1486039908.574729}]
-      # @example when parameter is a hash
-      #   arguments_with_metadata({arg1: 'value'}) #=> {:arg1 => 'value', :metadata => {:scheduled_at => 1486039908.574729}}
+      # It currently returns the schedule time as a Float number representing the milisencods
+      # since epoch.
+      #
+      # @example with hash argument
+      #   arguments_with_metadata({value: 1}, scheduled_at: Time.now)
+      #   #=> [{value: 1}, {scheduled_at: <miliseconds since epoch>}]
       #
       # @param args [Array|Hash]
+      # @param metadata [Hash]
       # @return [Array|Hash] arguments with added metadata
-      def arguments_with_metadata(args)
-        metadata_hash = {scheduled_at: Time.now.to_f}
+      def arguments_with_metadata(args, metadata)
         if args.is_a? Array
-          args.push(metadata_hash)
-        elsif args.is_a? Hash
-          args[:metadata] = metadata_hash
+          [*args, metadata]
+        else
+          [args, metadata]
         end
-        args
       end
 
     end

--- a/lib/sidekiq/scheduler.rb
+++ b/lib/sidekiq/scheduler.rb
@@ -403,7 +403,7 @@ module Sidekiq
       #
       # @param args [Array|Hash]
       # @param metadata [Hash]
-      # @return [Array|Hash] arguments with added metadata
+      # @return [Array] arguments with added metadata
       def arguments_with_metadata(args, metadata)
         if args.is_a? Array
           [*args, metadata]

--- a/spec/sidekiq/scheduler_spec.rb
+++ b/spec/sidekiq/scheduler_spec.rb
@@ -41,21 +41,41 @@ describe Sidekiq::Scheduler do
   end
 
   describe '.enqueue_job' do
+    let(:schedule_time) { Time.now }
+    let(:args) { '/tmp' }
     let(:scheduler_config) do
-      { 'class' => 'SomeWorker', 'queue' => 'high', 'args'  => '/tmp', 'cron' => '* * * * *' }
+      { 'class' => 'SomeWorker', 'queue' => 'high', 'args'  => args, 'cron' => '* * * * *' }
     end
 
     # The job should be loaded, since a missing rails_env means ALL envs.
     before { ENV['RAILS_ENV'] = 'production' }
 
-    it 'prepares the parameters' do
-      expect(Sidekiq::Client).to receive(:push).with({
-        'class' => SomeWorker,
-        'queue' => 'high',
-        'args' => ['/tmp']
-      })
+    context 'when it is a sidekiq worker' do
+      it 'prepares the parameters' do
+        expect(Sidekiq::Client).to receive(:push).with({
+          'class' => SomeWorker,
+          'queue' => 'high',
+          'args' => ['/tmp']
+        })
 
-      Sidekiq::Scheduler.enqueue_job(scheduler_config)
+        Sidekiq::Scheduler.enqueue_job(scheduler_config, schedule_time)
+      end
+    end
+
+    context 'when it is an activejob worker' do
+      before do
+        scheduler_config['class'] = EmailSender
+      end
+
+      specify 'enqueues the job as active job' do
+        expect_any_instance_of(EmailSender).to receive(:enqueue).with({
+          'class' => EmailSender,
+          'queue' => 'high',
+          'args' => ['/tmp']
+        })
+
+        Sidekiq::Scheduler.enqueue_job(scheduler_config, schedule_time)
+      end
     end
 
     context 'when worker class does not exist' do
@@ -70,28 +90,93 @@ describe Sidekiq::Scheduler do
           'args' => ['/tmp']
         })
 
-        Sidekiq::Scheduler.enqueue_job(scheduler_config)
+        Sidekiq::Scheduler.enqueue_job(scheduler_config, schedule_time)
       end
     end
 
     context 'when job is configured to receive metadata' do
-      let(:schedule_time) { Time.now }
-
       before do
         scheduler_config['include_metadata'] = true
       end
 
-      it 'pushes the job with the metadata in the arguments' do
-        Timecop.freeze(schedule_time) do
-          expect(Sidekiq::Client).to receive(:push).with({
-            'class' => SomeWorker,
+      context 'when called without a time argument' do
+        specify 'uses the current time' do
+          Timecop.freeze(schedule_time) do
+            expect(Sidekiq::Client).to receive(:push).with({
+              'class' => SomeWorker,
+              'queue' => 'high',
+              'args' => ['/tmp', {scheduled_at: schedule_time.to_f}]
+            })
+
+            Sidekiq::Scheduler.enqueue_job(scheduler_config)
+          end
+        end
+      end
+
+      context 'when arguments are already expanded' do
+        it 'pushes the job with the metadata as the last argument' do
+          Timecop.freeze(schedule_time) do
+            expect(Sidekiq::Client).to receive(:push).with({
+              'class' => SomeWorker,
+              'queue' => 'high',
+              'args' => ['/tmp', {scheduled_at: schedule_time.to_f}]
+            })
+
+            Sidekiq::Scheduler.enqueue_job(scheduler_config, schedule_time)
+          end
+        end
+      end
+
+      context 'when it is an active job worker' do
+        before do
+          scheduler_config['class'] = EmailSender
+        end
+
+        specify 'enqueues the job as active job' do
+          expect_any_instance_of(EmailSender).to receive(:enqueue).with({
+            'class' => EmailSender,
             'queue' => 'high',
             'args' => ['/tmp', {scheduled_at: schedule_time.to_f}]
           })
 
-          Sidekiq::Scheduler.enqueue_job(scheduler_config)
+          Sidekiq::Scheduler.enqueue_job(scheduler_config, schedule_time)
         end
       end
+
+      context 'when arguments contain a hash' do
+        let(:args) { { 'dir' => '/tmp' } }
+
+        it 'pushes the job with the metadata as the last argument' do
+          Timecop.freeze(schedule_time) do
+            expect(Sidekiq::Client).to receive(:push).with({
+              'class' => SomeWorker,
+              'queue' => 'high',
+              'args' => [{dir: '/tmp'}, {scheduled_at: schedule_time.to_f}]
+            })
+
+            Sidekiq::Scheduler.enqueue_job(scheduler_config, schedule_time)
+          end
+        end
+      end
+
+      context 'when arguments are empty' do
+        before do
+          scheduler_config.delete('args')
+        end
+
+        it 'pushes the job with the metadata as the only argument' do
+          Timecop.freeze(schedule_time) do
+            expect(Sidekiq::Client).to receive(:push).with({
+              'class' => SomeWorker,
+              'queue' => 'high',
+              'args' => [{scheduled_at: schedule_time.to_f}]
+            })
+
+            Sidekiq::Scheduler.enqueue_job(scheduler_config, schedule_time)
+          end
+        end
+      end
+
     end
   end
 
@@ -303,8 +388,7 @@ describe Sidekiq::Scheduler do
 
       expect {
         Sidekiq.set_schedule('other_job', ScheduleFaker.cron_schedule({'args' => 'sample'}))
-
-        Timecop.travel(6 * 60)
+        Timecop.travel(7 * 60)
         sleep 0.5
       }.to change { Sidekiq::Scheduler.scheduled_jobs.include?('other_job') }.to(true)
     end


### PR DESCRIPTION
Schedules support now a configuration to pass
a schedule metadata hash as the last argument to the
worker method.