### PR TITLE
Don't set schedule when not enabled

### DIFF
--- a/lib/sidekiq-scheduler/manager.rb
+++ b/lib/sidekiq-scheduler/manager.rb
@@ -18,7 +18,7 @@ module SidekiqScheduler
       Sidekiq::Scheduler.enabled = options[:enabled]
       Sidekiq::Scheduler.dynamic = options[:dynamic]
       Sidekiq::Scheduler.listened_queues_only = options[:listened_queues_only]
-      Sidekiq.schedule = options[:schedule]
+      Sidekiq.schedule = options[:schedule] if Sidekiq::Scheduler.enabled
     end
 
     def stop

--- a/spec/sidekiq-scheduler/manager_spec.rb
+++ b/spec/sidekiq-scheduler/manager_spec.rb
@@ -1,5 +1,4 @@
 describe SidekiqScheduler::Manager do
-
   describe '.new' do
     let(:previous_schedule) do
       {
@@ -47,6 +46,21 @@ describe SidekiqScheduler::Manager do
       expect {
         subject
       }.to change { Sidekiq.schedule }.to(options[:schedule])
+    end
+
+    context 'when not enabled' do
+      let(:options) do
+        {
+          enabled: false,
+          schedule: { 'current' => ScheduleFaker.cron_schedule('queue' => 'default') }
+        }
+      end
+
+      it 'does not set Sidekiq.schedule' do
+        expect {
+          subject
+        }.not_to change { Sidekiq.schedule }
+      end
     end
   end
 end


### PR DESCRIPTION
This change updates the manager to only set the schedule when
the `enabled` options is `true`. This means that we wont update 
the schedule in Redis when the config passes `enabled` as `false`.

The use case for this was running two processes with different
config options eg.

`bundle exec sidekiq -C config/sidekiq.yml`
`bundle exec sidekiq -C config/sidekiq_schedule.yml`

The `sidekiq_schedule.yml` contains a collection of scheduled
jobs and the `sidekiq.yml` does not contain any scheduled jobs.
What we were seeing was that depending on which is last to run
the `Sidekiq.get_schedule` (from Redis) could either contain the
schedule or return an empty hash.