### PR TITLE
Config hashie object with indifferent access

### DIFF
--- a/lib/sidekiq-scheduler/config_hash.rb
+++ b/lib/sidekiq-scheduler/config_hash.rb
@@ -1,0 +1,8 @@
+require 'hashie'
+
+module SidekiqScheduler
+  class ConfigHash < Hash
+    include Hashie::Extensions::MergeInitializer
+    include Hashie::Extensions::IndifferentAccess
+  end
+end

--- a/lib/sidekiq/scheduler.rb
+++ b/lib/sidekiq/scheduler.rb
@@ -3,6 +3,7 @@ require 'thwait'
 require 'sidekiq/util'
 require 'sidekiq-scheduler/manager'
 require 'sidekiq-scheduler/rufus_utils'
+require 'sidekiq-scheduler/config_hash'
 require 'json'
 
 module Sidekiq
@@ -266,6 +267,8 @@ module Sidekiq
       #
       # @return [Hash]
       def prepare_arguments(config)
+        config = SidekiqScheduler::ConfigHash.new(config)
+
         config['class'] = try_to_constantize(config['class'])
 
         if config['args'].is_a?(Hash)


### PR DESCRIPTION
Thanks for the great gem!

I noticed a bug where `ActiveJob` scheduled jobs do not recognize jobs scheduled with a `queue` key value.

ENV:
```
    rails (4.2.7.1)
    sidekiq (4.2.10)
    sidekiq-pro (3.4.5)
    sidekiq-scheduler (2.1.2)
```

Example Scheduler:
```
 job_name:
    cron: "30 0 * * * America/Los_Angeles"
    class: WorkerClass
    args: ["args", "for", "worker"]
    queue: "host-specific-queue"
    description: "process stuff"
```
 
The scheduled job above, is parsed as a hash with stringified keys. When the hash is passed to `WorkerClass.enqueue(config)` the stringified keys are ignored and the job is enqueued on the `default` queue unless `queue_as` is set.

Solution:
The gem is already including `Hashie` so I propose converting the config hash to a hashie hash with indifferent access before enqueuing.

I have not tested this change in Rails 5 so it's unclear if the hash with indifferent access is needed.

Current Workaround:
To avoid this issue, I added the below:

```ruby
class ApplicationJob < ActiveJob::Base
  def enqueue(options = {})
    super(options.symbolize_keys)
  end
end
```

This PR is intended as a example solution to open dialogue.

Thanks! 