### PR TITLE
Use Sorted-Set instead of Set to store 'schedules_changed' in redis

### DIFF
--- a/lib/sidekiq-scheduler/schedule.rb
+++ b/lib/sidekiq-scheduler/schedule.rb
@@ -104,7 +104,7 @@ module SidekiqScheduler
       existing_config = get_schedule(name)
       unless existing_config && existing_config == config
         Sidekiq.redis { |r| r.hset(:schedules, name, JSON.generate(config)) }
-        Sidekiq.redis { |r| r.sadd(:schedules_changed, name) }
+        Sidekiq.redis { |r| r.zadd(:schedules_changed, Time.now.to_f, name) }
       end
       config
     end
@@ -112,7 +112,7 @@ module SidekiqScheduler
     # remove a given schedule by name
     def remove_schedule(name)
       Sidekiq.redis { |r| r.hdel(:schedules, name) }
-      Sidekiq.redis { |r| r.sadd(:schedules_changed, name) }
+      Sidekiq.redis { |r| r.zadd(:schedules_changed, Time.now.to_f, name) }
     end
 
     private

--- a/spec/sidekiq-scheduler/schedule_spec.rb
+++ b/spec/sidekiq-scheduler/schedule_spec.rb
@@ -20,7 +20,7 @@ describe SidekiqScheduler::Schedule do
   end
 
   def changed_job?(job_id)
-    Sidekiq.redis { |redis| redis.sismember(:schedules_changed, job_id) }
+    Sidekiq.redis { |redis| !!redis.zrank(:schedules_changed, job_id) }
   end
 
   def job_from_redis_without_decoding(job_id)

--- a/spec/sidekiq/scheduler_spec.rb
+++ b/spec/sidekiq/scheduler_spec.rb
@@ -780,9 +780,9 @@ describe Sidekiq::Scheduler do
         }.to_not change { Sidekiq::Scheduler.scheduled_jobs.keys.size }
       end
 
-      it 'resets the changed flag from redis' do
+      it 'resets the instance variable current_change_score' do
         expect { Sidekiq::Scheduler.update_schedule }
-          .to change{ Sidekiq.redis { |r| r.scard(:schedules_changed) } }.from(1).to(0)
+          .to change{ Sidekiq::Scheduler.instance_variable_get(:@current_changed_score) }.to be_a Float
       end
     end
   end


### PR DESCRIPTION
As we discussed in issue #191 , `spop` may lead to unexpected results under distributed scene.

In this PR, I use `Sorted-Set` instead of `Set` to store schedules_changed info. It works like the db migration of Rails.

Notice, This RP will lead a break change:

If a schedules_change has been added before sidekiq server client starts up, the schedules_change will be ignored by the new instance of sidekiq server. Because the member of `schedules_changed` can only be update (its score) and never be deleted, we can't judge which is outdated or pre-added.