### PR TITLE
Fix non-loading schedule issue

### DIFF
--- a/lib/sidekiq-scheduler/schedule.rb
+++ b/lib/sidekiq-scheduler/schedule.rb
@@ -53,8 +53,6 @@ module SidekiqScheduler
     end
 
     def schedule
-      reload_schedule! unless @schedule
-
       @schedule
     end
 

--- a/lib/sidekiq-scheduler/web.rb
+++ b/lib/sidekiq-scheduler/web.rb
@@ -22,6 +22,8 @@ module SidekiqScheduler
       end
 
       app.get '/recurring-jobs/:name/toggle' do
+        Sidekiq.reload_schedule!
+
         Sidekiq::Scheduler.toggle_job_enabled(params[:name])
         redirect "#{root_path}recurring-jobs"
       end

--- a/spec/sidekiq-scheduler/schedule_spec.rb
+++ b/spec/sidekiq-scheduler/schedule_spec.rb
@@ -151,24 +151,4 @@ describe SidekiqScheduler::Schedule do
       expect(changed_job?(job_id)).to be_truthy
     end
   end
-
-  describe 'instance methods' do
-    let(:concrete_class) do
-      Class.new do
-        include SidekiqScheduler::Schedule
-      end
-    end
-
-    subject { concrete_class.new }
-
-    describe '#schedule' do
-      before do
-        subject.set_schedule(job_id, cron_hash)
-      end
-
-      it 'returns the schedule' do
-        expect(subject.schedule).to include(job_id)
-      end
-    end
-  end
 end

--- a/spec/sidekiq-scheduler/web_spec.rb
+++ b/spec/sidekiq-scheduler/web_spec.rb
@@ -71,18 +71,17 @@ describe Sidekiq::Web do
   end
 
   describe '/recurring-jobs/:name/toggle' do
-    context 'when the job is enabled' do
-      it 'disables the job' do
-        expect { get "/recurring-jobs/#{URI.escape(enabled_job_name)}/toggle" }
-          .to change { Sidekiq::Scheduler.job_enabled?(enabled_job_name) }.from(true).to(false)
-      end
+    subject { get "/recurring-jobs/#{URI.escape(enabled_job_name)}/toggle" }
+
+    it 'toggles job enabled flag' do
+      expect { subject }
+        .to change { Sidekiq::Scheduler.job_enabled?(enabled_job_name) }.from(true).to(false)
     end
 
-    context 'when the job is disabled' do
-      it 'enables the job' do
-        expect { get "/recurring-jobs/#{URI.escape(disabled_job_name)}/toggle" }
-          .to change { Sidekiq::Scheduler.job_enabled?(disabled_job_name) }.from(false).to(true)
-      end
+    it 'reloads the schedule' do
+      expect(Sidekiq).to receive(:reload_schedule!)
+
+      get "/recurring-jobs/#{URI.escape(enabled_job_name)}/toggle"
     end
   end
 


### PR DESCRIPTION
Schedule was being fetched only from Redis during startup, so when no data was present in Redis the
schedule will become empty.

The bug was introduced while solving another issue related to the schedule not loaded in the Web UI
process.

Fixed both issues by not fetching from Redis during startup, and loading schedule from Redis at the
Web UI 'toggle' route.