### PR TITLE
Relax the rufus-scheduler dependency

### DIFF
--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'sidekiq',         '>= 3'
   s.add_dependency 'redis',           '~> 3'
-  s.add_dependency 'rufus-scheduler', '~> 3.2'
+  s.add_dependency 'rufus-scheduler', '>= 3.2', '< 4.0'
   s.add_dependency 'tilt',            '>= 1.4.0'
 
   s.add_development_dependency 'rake',                    '~> 10.0'


### PR DESCRIPTION
I would like to use a new version (3.3.3) of rufus-scheduler which takes the time zone from Rails

https://github.com/jmettraux/rufus-scheduler/commit/dc9e9df051b2d9f5379f3cd5c703f078b35b8e3a

https://github.com/jmettraux/rufus-scheduler/blob/master/CHANGELOG.txt

This might mean some jobs are missed due to DST changes (i.e. if the before the TZ was UTC and now its Europe/London) so maybe this change should come with a warning...?