### PR TITLE
Don't explicitly set queue name for ActiveJobs

### DIFF
--- a/lib/sidekiq-scheduler/schedule.rb
+++ b/lib/sidekiq-scheduler/schedule.rb
@@ -141,8 +141,6 @@ module SidekiqScheduler
 
       if klass.respond_to?(:sidekiq_options)
         klass.sidekiq_options['queue']
-      elsif klass.respond_to?(:queue_name)
-        klass.queue_name
       end
     end
 

--- a/lib/sidekiq/scheduler.rb
+++ b/lib/sidekiq/scheduler.rb
@@ -245,7 +245,9 @@ module Sidekiq
       end
 
       def enqueue_with_active_job(config)
-        options = { queue: config['queue'] }
+        options = {
+          queue: config['queue']
+        }.keep_if { |_, v| !v.nil? }
 
         initialize_active_job(config['class'], config['args']).enqueue(options)
       end

--- a/spec/sidekiq-scheduler/schedule_spec.rb
+++ b/spec/sidekiq-scheduler/schedule_spec.rb
@@ -67,17 +67,6 @@ describe SidekiqScheduler::Schedule do
         expect(SidekiqScheduler::Store.job_from_redis(job_id)['queue']).to eq('system')
       end
     end
-
-    context 'when job is an active job' do
-      let(:job_id) { 'email_sender' }
-      let(:schedule) { { 'class' => 'EmailSender' } }
-
-      it 'infers the queue name' do
-        subject
-
-        expect(SidekiqScheduler::Store.job_from_redis(job_id)['queue']).to eq('email')
-      end
-    end
   end
 
   describe '.set_schedule' do

--- a/spec/sidekiq/scheduler_spec.rb
+++ b/spec/sidekiq/scheduler_spec.rb
@@ -82,6 +82,18 @@ describe Sidekiq::Scheduler do
 
         Sidekiq::Scheduler.enqueue_job(scheduler_config, schedule_time)
       end
+
+      context 'when queue is not configured' do
+        before do
+          scheduler_config.delete('queue')
+        end
+
+        specify 'does not include :queue option' do
+          expect_any_instance_of(EmailSender).to receive(:enqueue).with({})
+
+          Sidekiq::Scheduler.enqueue_job(scheduler_config, schedule_time)
+        end
+      end
     end
 
     context 'when worker class does not exist' do


### PR DESCRIPTION
Asking for an ActiveJob's queue gets back the queue name including a prefix in case is set with
`config.active_job.queue_name_prefix`, and then setting that queue name explicitly while invoking
the job will turn to a duplicate prefix.

Changed to only set the queue name when one is configured via sidekiq.yml