### PR TITLE
Support :dynamic_every option (default 5s) for :dynamic

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Available options are:
 
 ``` yaml
 :dynamic: <if true the schedule can be modified in runtime [false by default]>
+:dynamic_every: <if dynamic is true, the schedule is reloaded every interval [5s by default]>
 :enabled: <enables scheduler if true [true by default]>
 :scheduler:
   :listened_queues_only: <push jobs whose queue is being listened by sidekiq [false by default]>
@@ -244,7 +245,7 @@ Sidekiq.set_schedule('heartbeat', { 'every' => ['1m'], 'class' => 'HeartbeatWork
 
 If the schedule did not exist it will be created, if it existed it will be updated.
 
-When `:dynamic` flag is set to `true`, schedule changes are loaded every 5 seconds.
+When `:dynamic` flag is set to `true`, schedule changes are loaded every 5 seconds. Use the `:dynamic_every` flag for a different interval.
 
 ``` yaml
 # config/sidekiq.yml

--- a/lib/sidekiq-scheduler.rb
+++ b/lib/sidekiq-scheduler.rb
@@ -10,6 +10,9 @@ Sidekiq.configure_server do |config|
     dynamic = Sidekiq::Scheduler.dynamic
     dynamic = dynamic.nil? ? config.options.fetch(:dynamic, false) : dynamic
 
+    dynamic_every = Sidekiq::Scheduler.dynamic_every
+    dynamic_every = dynamic_every.nil? ? config.options.fetch(:dynamic_every, '5s') : dynamic_every
+
     enabled = Sidekiq::Scheduler.enabled
     enabled = enabled.nil? ? config.options.fetch(:enabled, true) : enabled
 
@@ -22,9 +25,10 @@ Sidekiq.configure_server do |config|
     schedule ||= config.options[:schedule] || {}
 
     scheduler_options = {
-      dynamic:   dynamic,
-      enabled:   enabled,
-      schedule:  schedule,
+      dynamic:       dynamic,
+      dynamic_every: dynamic_every,
+      enabled:       enabled,
+      schedule:      schedule,
       listened_queues_only: listened_queues_only
     }
 

--- a/lib/sidekiq-scheduler/manager.rb
+++ b/lib/sidekiq-scheduler/manager.rb
@@ -17,6 +17,7 @@ module SidekiqScheduler
     def initialize(options)
       Sidekiq::Scheduler.enabled = options[:enabled]
       Sidekiq::Scheduler.dynamic = options[:dynamic]
+      Sidekiq::Scheduler.dynamic_every = options[:dynamic_every]
       Sidekiq::Scheduler.listened_queues_only = options[:listened_queues_only]
       Sidekiq.schedule = options[:schedule] if Sidekiq::Scheduler.enabled
     end

--- a/lib/sidekiq/scheduler.rb
+++ b/lib/sidekiq/scheduler.rb
@@ -27,6 +27,9 @@ module Sidekiq
       # Set to update the schedule in runtime in a given time period.
       attr_accessor :dynamic
 
+      # Set to update the schedule in runtime dynamically per this period.
+      attr_accessor :dynamic_every
+
       # Set to schedule jobs only when will be pushed to queues listened by sidekiq
       attr_accessor :listened_queues_only
 
@@ -55,7 +58,7 @@ module Sidekiq
           if dynamic
             Sidekiq.reload_schedule!
             @current_changed_score = Time.now.to_f
-            rufus_scheduler.every('5s') do
+            rufus_scheduler.every(dynamic_every) do
               update_schedule
             end
           end

--- a/spec/sidekiq-scheduler/manager_spec.rb
+++ b/spec/sidekiq-scheduler/manager_spec.rb
@@ -7,6 +7,7 @@ describe SidekiqScheduler::Manager do
       {
         enabled: enabled,
         dynamic: true,
+        dynamic_every: '5s',
         listened_queues_only: true,
         schedule: { 'current' => ScheduleFaker.cron_schedule('queue' => 'default') }
       }
@@ -15,6 +16,7 @@ describe SidekiqScheduler::Manager do
     before do
       Sidekiq::Scheduler.enabled = nil
       Sidekiq::Scheduler.dynamic = nil
+      Sidekiq::Scheduler.dynamic_every = nil
       Sidekiq::Scheduler.listened_queues_only = nil
       Sidekiq.schedule = { previous: ScheduleFaker.cron_schedule }
     end


### PR DESCRIPTION
In some situations it doesn't make sense for a queue, which is
updated very rarely, to continually parse the scheduled queue
for new changes.