### PR TITLE
CI against Ruby 2.3/2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: ruby
 rvm:
+  - 2.4
+  - 2.3
   - 2.2


### PR DESCRIPTION
CI against Ruby 2.3/2.4

https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-3-5-released/
https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-4-2-released/