### PR TITLE
Add note for connection pool configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,18 @@ from the `config.time_zone` value, make sure it's the right format, e.g. with:
 ActiveSupport::TimeZone.find_tzinfo(Rails.configuration.time_zone).name
 ```
 
+## Notes about connection pooling
+
+If you're configuring your own Redis connection pool, you need to make sure the size is adequate to be inclusive of both Sidekiq's own connection pool and Rufus Scheduler's.
+
+That's a minimum of `concurrency` + 5 (per the [Sidekiq wiki](https://github.com/mperham/sidekiq/wiki/Using-Redis#complete-control)) + `Rufus::Scheduler::MAX_WORK_THREADS` (28 as of this writing; per the [Rufus README](https://github.com/jmettraux/rufus-scheduler#max_work_threads)), for a total of 58 with the default `concurrency` of 25.
+
+You can also override the thread pool size in Rufus Scheduler by setting e.g.:
+
+```
+Sidekiq::Scheduler.rufus_scheduler_options = { max_work_threads: 5 }
+```
+
 ## Notes about running on Multiple Hosts
 
 Under normal conditions, `cron` and `at` jobs are pushed once regardless of the number of `sidekiq-scheduler` running instances,


### PR DESCRIPTION
Spent some time tracking down this error and thought a docs update would be helpful:

```
{ 70352380284820 rufus-scheduler intercepted an error:
  70352380284820   job:
  70352380284820     Rufus::Scheduler::EveryJob "10s" {:first_in=>"1s", :job=>true, :tags=>["example_job"]}
  70352380284820   error:
  70352380284820     70352380284820
  70352380284820     Timeout::Error
  70352380284820     Waited 5 sec
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/connection_pool-2.2.1/lib/connection_pool/timed_stack.rb:86:in `block (2 levels) in pop'
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/connection_pool-2.2.1/lib/connection_pool/timed_stack.rb:78:in `loop'
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/connection_pool-2.2.1/lib/connection_pool/timed_stack.rb:78:in `block in pop'
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/connection_pool-2.2.1/lib/connection_pool/timed_stack.rb:77:in `synchronize'
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/connection_pool-2.2.1/lib/connection_pool/timed_stack.rb:77:in `pop'
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/connection_pool-2.2.1/lib/connection_pool.rb:89:in `checkout'
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/connection_pool-2.2.1/lib/connection_pool.rb:61:in `block in with'
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/connection_pool-2.2.1/lib/connection_pool.rb:60:in `handle_interrupt'
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/connection_pool-2.2.1/lib/connection_pool.rb:60:in `with'
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq.rb:92:in `redis'
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sidekiq-scheduler-2.2.1/lib/sidekiq-scheduler/redis_manager.rb:192:in `hget'
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sidekiq-scheduler-2.2.1/lib/sidekiq-scheduler/redis_manager.rb:21:in `get_job_state'
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sidekiq-scheduler-2.2.1/lib/sidekiq-scheduler/scheduler.rb:370:in `schedule_state'
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sidekiq-scheduler-2.2.1/lib/sidekiq-scheduler/scheduler.rb:333:in `job_enabled?'
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/sidekiq-scheduler-2.2.1/lib/sidekiq-scheduler/scheduler.rb:357:in `block in new_job'
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rufus-scheduler-3.4.2/lib/rufus/scheduler/jobs.rb:210:in `do_call'
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rufus-scheduler-3.4.2/lib/rufus/scheduler/jobs.rb:254:in `trigger_now'
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rufus-scheduler-3.4.2/lib/rufus/scheduler/jobs.rb:296:in `block (3 levels) in start_work_thread'
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rufus-scheduler-3.4.2/lib/rufus/scheduler/jobs.rb:299:in `block (2 levels) in start_work_thread'
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rufus-scheduler-3.4.2/lib/rufus/scheduler/jobs.rb:285:in `loop'
  70352380284820       /Users/zachwalton/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rufus-scheduler-3.4.2/lib/rufus/scheduler/jobs.rb:285:in `block in start_work_thread'
```