### PR TITLE
Provide a shutdown option to rufus-scheduler

### DIFF
--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -201,8 +201,8 @@ module SidekiqScheduler
 
       # Stops old rufus scheduler and creates a new one.  Returns the new
       # rufus scheduler
-      def clear_schedule!
-        rufus_scheduler.stop
+      def clear_schedule!(opt: :wait)
+        rufus_scheduler.stop(opt)
         @rufus_scheduler = nil
         @@scheduled_jobs = {}
         rufus_scheduler


### PR DESCRIPTION
I've been resolving an issue where calling clear_schedule! repeatedly on production is leaving behind hundreds of threads, which are all waiting waiting here:

```
rufus-scheduler-3.4.2/lib/rufus/scheduler/jobs.rb:287:in `pop'
rufus-scheduler-3.4.2/lib/rufus/scheduler/jobs.rb:287:in `block (2 levels) in start_work_thread'
rufus-scheduler-3.4.2/lib/rufus/scheduler/jobs.rb:285:in `loop'
rufus-scheduler-3.4.2/lib/rufus/scheduler/jobs.rb:285:in `block in start_work_thread'
```

This is what it looks like in production, before (and after) this commit:

![threads-1](https://user-images.githubusercontent.com/3889656/38115394-5c5a36e2-3408-11e8-96ba-704ec655adc5.png)

By default, calling `rufus_scheduler.stop` just lets [all of the work threads continue running](https://github.com/jmettraux/rufus-scheduler/blob/440400c5695c74b005e9baedc6a1d56c28e4c354/lib/rufus/scheduler.rb#L114) and they can leak to their hearts content. 

This commit makes all of the existing work threads join the current thread before clearing the schedule, meaning that the threads no longer leak by default.