### PR TITLE
Allow intervals lower than 1 second

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gemspec

--- a/lib/sidekiq-scheduler/redis_manager.rb
+++ b/lib/sidekiq-scheduler/redis_manager.rb
@@ -131,7 +131,7 @@ module SidekiqScheduler
       job_key = pushed_job_key(job_name)
       registered, _ = Sidekiq.redis do |r|
         r.pipelined do
-          r.zadd(job_key, time.to_i, time.to_i)
+          r.zadd(job_key, time.to_f, time.to_f)
           r.expire(job_key, REGISTERED_JOBS_THRESHOLD_IN_SECONDS)
         end
       end

--- a/spec/sidekiq-scheduler/redis_manager_spec.rb
+++ b/spec/sidekiq-scheduler/redis_manager_spec.rb
@@ -291,7 +291,7 @@ describe SidekiqScheduler::RedisManager do
     it 'should store the job instance' do
       subject
 
-      expect(SidekiqScheduler::Store.zrange('sidekiq-scheduler:pushed:some_job', 0, -1)).to eql([time.to_i.to_s])
+      expect(SidekiqScheduler::Store.zrange('sidekiq-scheduler:pushed:some_job', 0, -1)).to eql([time.to_f.to_s])
     end
 
     it 'should add an expiration key' do

--- a/spec/sidekiq-scheduler/redis_manager_spec.rb
+++ b/spec/sidekiq-scheduler/redis_manager_spec.rb
@@ -308,7 +308,7 @@ describe SidekiqScheduler::RedisManager do
       it { is_expected.to be_falsey }
 
       context 'when registering the new instance with a different time' do
-        let(:time) { current_time + 1 }
+        let(:time) { current_time + 0.5 }
 
         it { is_expected.to be_truthy }
       end

--- a/spec/sidekiq-scheduler/scheduler_spec.rb
+++ b/spec/sidekiq-scheduler/scheduler_spec.rb
@@ -693,15 +693,17 @@ describe SidekiqScheduler::Scheduler do
     it 'registers the enqueued job' do
       expect {
         described_class.idempotent_job_enqueue(job_name, time, config)
-      }.to change { enqueued_jobs_registry.last == time.to_i.to_s }.from(false).to(true)
+      }.to change { enqueued_jobs_registry.last == time.to_f.to_s }.from(false).to(true)
     end
 
     context 'when elder enqueued jobs' do
-      let(:some_time_ago) { time - SidekiqScheduler::RedisManager::REGISTERED_JOBS_THRESHOLD_IN_SECONDS }
+      let!(:some_time_ago) { time - (SidekiqScheduler::RedisManager::REGISTERED_JOBS_THRESHOLD_IN_SECONDS + 1) }
 
-      let(:near_time_ago) { time - SidekiqScheduler::RedisManager::REGISTERED_JOBS_THRESHOLD_IN_SECONDS  / 2 }
+      let!(:near_time_ago) { time - (SidekiqScheduler::RedisManager::REGISTERED_JOBS_THRESHOLD_IN_SECONDS + 1) / 2.0 }
 
-      before  do
+      before do
+        time
+
         Timecop.freeze(some_time_ago) do
           described_class.register_job_instance(job_name, some_time_ago)
         end
@@ -714,7 +716,7 @@ describe SidekiqScheduler::Scheduler do
       it 'deregisters elder enqueued jobs' do
         expect {
           described_class.idempotent_job_enqueue(job_name, time, config)
-        }.to change { enqueued_jobs_registry.first == some_time_ago.to_i.to_s }.from(true).to(false)
+        }.to change { enqueued_jobs_registry.first == some_time_ago.to_f.to_s }.from(true).to(false)
       end
     end
 


### PR DESCRIPTION
I'm currently trying to do a simple scheduler of a half second, but I noticed that the current implementation of the gem does not consider intervals lower than 1 second due to a `time.to_i` conversion. With this PR I changed the conversion into float.

I hope this could be useful.

Thank you.