### PR TITLE
Sort jobs by name on the web UI

### DIFF
--- a/lib/sidekiq-scheduler/job_presenter.rb
+++ b/lib/sidekiq-scheduler/job_presenter.rb
@@ -66,7 +66,7 @@ module SidekiqScheduler
     def self.build_collection(schedule_hash)
       schedule_hash ||= {}
 
-      schedule_hash.map do |name, job_spec|
+      schedule_hash.sort.map do |name, job_spec|
         new(name, job_spec)
       end
     end

--- a/spec/sidekiq-scheduler/job_presenter_spec.rb
+++ b/spec/sidekiq-scheduler/job_presenter_spec.rb
@@ -115,10 +115,10 @@ describe SidekiqScheduler::JobPresenter do
     end
 
     context 'when there is a schedule hash' do
-      let(:schedule_hash) { { first_job_name: {}, second_job_name: {} } }
+      let(:schedule_hash) { { c_job: {}, a_job: {}, b_job: {}, d_job: {} } }
 
-      it "initializes an object with the job's data" do
-        expect(subject.map(&:name)).to eq([:first_job_name, :second_job_name])
+      it "initializes an object with the job's data in alphabetical order" do
+        expect(subject.map(&:name)).to eq([:a_job, :b_job, :c_job, :d_job])
       end
     end
   end


### PR DESCRIPTION
Sort schedule jobs by name. Closes https://github.com/moove-it/sidekiq-scheduler/issues/258.