### PR TITLE
Mark web specs related to sidekiq stats as pending

### DIFF
--- a/spec/sidekiq-scheduler/web_spec.rb
+++ b/spec/sidekiq-scheduler/web_spec.rb
@@ -37,7 +37,10 @@ describe Sidekiq::Web do
     subject { get '/recurring-jobs' }
 
     context 'when the next execution time is not setted' do
-      it { is_expected.to be_successful }
+      it do
+        pending 'due to failure in mock_redis when pipelining array replies'
+        is_expected.to be_successful
+      end
 
       describe 'response body' do
         subject do
@@ -46,6 +49,7 @@ describe Sidekiq::Web do
         end
 
         it 'shows schedule' do
+          pending 'due to failure in mock_redis when pipelining array replies'
           is_expected.to match(/Foo Job/)
           is_expected.to match(/FooClass/)
           is_expected.to match(/0 \* \* \* \* US\/Eastern/)
@@ -67,7 +71,10 @@ describe Sidekiq::Web do
     context 'when the next execution time is setted' do
       before { SidekiqScheduler::Utils.update_job_next_time(enabled_job_name, '2016-07-11T13:29:47Z') }
 
-      it { is_expected.to be_successful }
+      it do
+        pending 'due to failure in mock_redis when pipelining array replies'
+        is_expected.to be_successful
+      end
 
       describe 'response body' do
         subject do
@@ -75,7 +82,10 @@ describe Sidekiq::Web do
           last_response.body
         end
 
-        it { is_expected.to match(/2016-07-11T13:29:47Z/) }
+        it do
+          pending 'due to failure in mock_redis when pipelining array replies'
+          is_expected.to match(/2016-07-11T13:29:47Z/)
+        end
       end
     end
   end


### PR DESCRIPTION
Those specs are were failing due to a error in mock_redis pipelined
implementation. In mock_redis implementation, array replies are
being flatten and contactenated with other array replies within
the same pipeline, while they shouldn't be contactenated.