### PR TITLE
Remove defunct reset method

### DIFF
--- a/lib/sidekiq-scheduler/manager.rb
+++ b/lib/sidekiq-scheduler/manager.rb
@@ -37,10 +37,6 @@ module SidekiqScheduler
       @scheduler_instance.load_schedule!
     end
 
-    def reset
-      clear_scheduled_work
-    end
-
     private
 
     def load_scheduler_options(options)


### PR DESCRIPTION
I was looking through the source here to find a way to reset my state without digging into Redis, and happened up the `reset` method - which, as of https://github.com/moove-it/sidekiq-scheduler/commit/70de80cbc6a1bc675bf4e741b8ce2169635059b1, points to a method that no longer exists.

I just removed it in case anyone else happened to be looking for similar functionality. Looks like only `start`/`stop` are leveraged in the Sidekiq startup hook.