### PR TITLE
Changed redis "exists" method calls to "exists?"

### DIFF
--- a/lib/sidekiq-scheduler/redis_manager.rb
+++ b/lib/sidekiq-scheduler/redis_manager.rb
@@ -96,7 +96,7 @@ module SidekiqScheduler
     #
     # @return [Boolean] true if the schedules key is set, false otherwise
     def self.schedule_exist?
-      Sidekiq.redis { |r| r.exists(:schedules) }
+      Sidekiq.redis { |r| r.exists?(:schedules) }
     end
 
     # Returns all the schedule changes for a given time range.

--- a/spec/support/store.rb
+++ b/spec/support/store.rb
@@ -59,7 +59,7 @@ module SidekiqScheduler
     end
 
     def self.exists(key)
-      Sidekiq.redis { |r| r.exists(key) }
+      Sidekiq.redis { |r| r.exists?(key) }
     end
 
     def self.hexists(hash_key, field_key)


### PR DESCRIPTION
Redis "exists" method calls were changed to "exists?" to address a deprecation warning from the redis-rb gem.

Addresses https://github.com/moove-it/sidekiq-scheduler/issues/305.