### PR TITLE
Update README to reflect reading Rails timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,8 +272,9 @@ Sidekiq.get_schedule
 
 ## Time zones
 
-Note that if you use the cron syntax, this will be interpreted as in the server time zone
-rather than the `config.time_zone` specified in Rails.
+Note that if you use the cron syntax and are not running a Rails app, this will be interpreted in the server time zone.
+
+In a Rails app, [rufus-scheduler](https://github.com/jmettraux/rufus-scheduler) (>= 3.3.3) will use the `config.time_zone` specified in Rails.
 
 You can explicitly specify the time zone that rufus-scheduler will use:
 


### PR DESCRIPTION
It appears that rufus-scheduler version 3.3.3 [uses the Rails timezone](https://github.com/jmettraux/rufus-scheduler/commit/dc9e9df051b2d9f5379f3cd5c703f078b35b8e3a) if Rails is detected. [This commit](https://github.com/moove-it/sidekiq-scheduler/commit/4b7eb813c67794503f8e1586f937be525d57e1df) bumps the version of rufus-scheduler, allowing it to upgrade to 3.x, which includes the change.

This change modifies the README regarding cron syntax, to indicate that the current version of sidekiq_scheduler does use the Rails timezone when parsing cron statements.

Fixes #309 