### PR TITLE
Replace deprecated method call `URI.escape`

### DIFF
--- a/spec/sidekiq-scheduler/web_spec.rb
+++ b/spec/sidekiq-scheduler/web_spec.rb
@@ -91,7 +91,7 @@ describe Sidekiq::Web do
   end
 
   describe '/recurring-jobs/:name/toggle' do
-    subject { get "/recurring-jobs/#{URI.escape(enabled_job_name)}/toggle" }
+    subject { get "/recurring-jobs/#{URI.encode_www_form_component(enabled_job_name)}/toggle" }
 
     it 'toggles job enabled flag' do
       expect { subject }
@@ -106,7 +106,7 @@ describe Sidekiq::Web do
   end
 
   describe 'GET /recurring-jobs/:name/enqueue' do
-    subject { get "/recurring-jobs/#{URI.escape(job_name)}/enqueue" }
+    subject { get "/recurring-jobs/#{URI.encode_www_form_component(job_name)}/enqueue" }
 
     let(:job_name) { enabled_job_name }
     let(:job) { jobs[job_name] }

--- a/web/views/recurring_jobs.erb
+++ b/web/views/recurring_jobs.erb
@@ -34,7 +34,7 @@
             </span>
           </td>
           <td class="text-center">
-            <a class="btn btn-warn btn-xs" href="<%= root_path %>recurring-jobs/<%= URI.escape(job.name) %>/enqueue">
+            <a class="btn btn-warn btn-xs" href="<%= root_path %>recurring-jobs/<%= URI.encode_www_form_component(job.name) %>/enqueue">
               <%= t('enqueue_now') %>
             </a>
             <a class="btn <%= job.enabled? ? "btn-primary" : "btn-warn"%> btn-xs" href="<%= root_path %>recurring-jobs/<%= URI.encode_www_form_component(job.name) %>/toggle">

--- a/web/views/recurring_jobs.erb
+++ b/web/views/recurring_jobs.erb
@@ -37,7 +37,7 @@
             <a class="btn btn-warn btn-xs" href="<%= root_path %>recurring-jobs/<%= URI.escape(job.name) %>/enqueue">
               <%= t('enqueue_now') %>
             </a>
-            <a class="btn <%= job.enabled? ? "btn-primary" : "btn-warn"%> btn-xs" href="<%= root_path %>recurring-jobs/<%= URI.escape(job.name) %>/toggle">
+            <a class="btn <%= job.enabled? ? "btn-primary" : "btn-warn"%> btn-xs" href="<%= root_path %>recurring-jobs/<%= URI.encode_www_form_component(job.name) %>/toggle">
               <%= job.enabled? ? t('disable') : t('enable') %>
             </a>
           </td>


### PR DESCRIPTION
Replace deprecated method call `URI.escape` with the recommended `URI.encode_www_form_component` method