### PR TITLE
Eliminate circular require: scheduler.rb <=> manager.rb

### DIFF
--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -2,7 +2,6 @@ require 'rufus/scheduler'
 require 'thwait'
 require 'sidekiq/util'
 require 'json'
-require 'sidekiq-scheduler/manager'
 require 'sidekiq-scheduler/rufus_utils'
 require 'sidekiq-scheduler/redis_manager'
 


### PR DESCRIPTION
Requiring this gem causes "circular require" warning, e.g.

```
$ ruby -rsidekiq-scheduler -wep
...
.../rubygems/core_ext/kernel_require.rb:94: warning: .../rubygems/core_ext/kernel_require.rb:94: warning: loading in progress, circular require considered harmful - .../gems/sidekiq-scheduler-3.0.1/lib/sidekiq-scheduler/scheduler.rb
	from .../rubygems/core_ext/kernel_require.rb:147:in  `require'
	from .../rubygems/core_ext/kernel_require.rb:158:in  `rescue in require'
	from .../rubygems/core_ext/kernel_require.rb:158:in  `require'
	from .../gems/sidekiq-scheduler-3.0.1/lib/sidekiq-scheduler.rb:4:in  `<top (required)>'
	from .../gems/sidekiq-scheduler-3.0.1/lib/sidekiq-scheduler.rb:4:in  `require_relative'
	from .../gems/sidekiq-scheduler-3.0.1/lib/sidekiq/scheduler.rb:1:in  `<top (required)>'
	from .../rubygems/core_ext/kernel_require.rb:94:in  `require'
	from .../rubygems/core_ext/kernel_require.rb:94:in  `require'
	from .../gems/sidekiq-scheduler-3.0.1/lib/sidekiq-scheduler/scheduler.rb:5:in  `<top (required)>'
	from .../rubygems/core_ext/kernel_require.rb:94:in  `require'
	from .../rubygems/core_ext/kernel_require.rb:94:in  `require'
	from .../gems/sidekiq-scheduler-3.0.1/lib/sidekiq-scheduler/manager.rb:6:in  `<top (required)>'
	from .../rubygems/core_ext/kernel_require.rb:94:in  `require'
	from .../rubygems/core_ext/kernel_require.rb:94:in  `require'
```

This is because `sidekiq-scheduler/scheduler` requires `sidekiq-scheduler/manager`, and `sidekiq-scheduler/manager` requires back `sidekiq-scheduler/scheduler`.
But since `sidekiq-scheduler.rb` already requires `sidekiq-scheduler/manager` we need not to repeat that require twice.