### PR TITLE
Replace obselete method

### DIFF
--- a/web/views/recurring_jobs.erb
+++ b/web/views/recurring_jobs.erb
@@ -34,10 +34,10 @@
             </span>
           </td>
           <td class="text-center">
-            <a class="btn btn-warn btn-xs" href="<%= root_path %>recurring-jobs/<%= URI.escape(job.name) %>/enqueue">
+            <a class="btn btn-warn btn-xs" href="<%= root_path %>recurring-jobs/<%= URI.encode_www_form_component(job.name) %>/enqueue">
               <%= t('enqueue_now') %>
             </a>
-            <a class="btn <%= job.enabled? ? "btn-primary" : "btn-warn"%> btn-xs" href="<%= root_path %>recurring-jobs/<%= URI.escape(job.name) %>/toggle">
+            <a class="btn <%= job.enabled? ? "btn-primary" : "btn-warn"%> btn-xs" href="<%= root_path %>recurring-jobs/<%= URI.encode_www_form_component(job.name) %>/toggle">
               <%= job.enabled? ? t('disable') : t('enable') %>
             </a>
           </td>


### PR DESCRIPTION
`URI.escape` has been made obselete and the documentation recommends the following

> This method is obsolete and should not be used. Instead, use CGI.escape, URI.encode_www_form or URI.encode_www_form_component depending on your specific use case.
> https://ruby-doc.org/stdlib-2.4.1/libdoc/uri/rdoc/URI/Escape.html

Decided against using `CGI.escape` to avoid requiring it and based on my limited testing seems like `encode_www_form_component` will still do the same thing.

Fixes #323 