### PR TITLE
Gemfile: Refer to https for rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gemspec


### PR DESCRIPTION
This PR uses https to talk to rubygems.org for finding gems in development/CI.