### PR TITLE
Add support for Ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 3.0
   - 2.7
   - 2.6
   - 2.5

--- a/spec/sidekiq-scheduler/web_spec.rb
+++ b/spec/sidekiq-scheduler/web_spec.rb
@@ -91,7 +91,7 @@ describe Sidekiq::Web do
   end
 
   describe '/recurring-jobs/:name/toggle' do
-    subject { get "/recurring-jobs/#{URI.escape(enabled_job_name)}/toggle" }
+    subject { get "/recurring-jobs/#{ERB::Util.url_encode(enabled_job_name)}/toggle" }
 
     it 'toggles job enabled flag' do
       expect { subject }
@@ -106,7 +106,7 @@ describe Sidekiq::Web do
   end
 
   describe 'GET /recurring-jobs/:name/enqueue' do
-    subject { get "/recurring-jobs/#{URI.escape(job_name)}/enqueue" }
+    subject { get "/recurring-jobs/#{ERB::Util.url_encode(job_name)}/enqueue" }
 
     let(:job_name) { enabled_job_name }
     let(:job) { jobs[job_name] }

--- a/web/views/recurring_jobs.erb
+++ b/web/views/recurring_jobs.erb
@@ -34,10 +34,10 @@
             </span>
           </td>
           <td class="text-center">
-            <a class="btn btn-warn btn-xs" href="<%= root_path %>recurring-jobs/<%= URI.escape(job.name) %>/enqueue">
+            <a class="btn btn-warn btn-xs" href="<%= root_path %>recurring-jobs/<%= ERB::Util.url_encode(job.name) %>/enqueue">
               <%= t('enqueue_now') %>
             </a>
-            <a class="btn <%= job.enabled? ? "btn-primary" : "btn-warn"%> btn-xs" href="<%= root_path %>recurring-jobs/<%= URI.escape(job.name) %>/toggle">
+            <a class="btn <%= job.enabled? ? "btn-primary" : "btn-warn"%> btn-xs" href="<%= root_path %>recurring-jobs/<%= ERB::Util.url_encode(job.name) %>/toggle">
               <%= job.enabled? ? t('disable') : t('enable') %>
             </a>
           </td>


### PR DESCRIPTION
Use ERB::Util.url_encode instead of deprecated URI.escape (#333)
Add more rubies to test matrix