### PR TITLE
fix redis exists deprecation warning

### DIFF
--- a/lib/sidekiq-scheduler/redis_manager.rb
+++ b/lib/sidekiq-scheduler/redis_manager.rb
@@ -96,7 +96,13 @@ module SidekiqScheduler
     #
     # @return [Boolean] true if the schedules key is set, false otherwise
     def self.schedule_exist?
-      Sidekiq.redis { |r| r.exists(:schedules) }
+      Sidekiq.redis do |r|
+        if r.respond_to?(:exists?)
+          r.exists?(:schedules)
+        else
+          !!r.exists(:schedules)
+        end
+      end
     end
 
     # Returns all the schedule changes for a given time range.

--- a/spec/support/store.rb
+++ b/spec/support/store.rb
@@ -59,7 +59,13 @@ module SidekiqScheduler
     end
 
     def self.exists(key)
-      Sidekiq.redis { |r| r.exists(key) }
+      Sidekiq.redis do |r|
+        if r.respond_to?(:exists?)
+          r.exists?(key)
+        else
+          !!r.exists(key)
+        end
+      end
     end
 
     def self.hexists(hash_key, field_key)


### PR DESCRIPTION
With redis 4.2.5 I get deprecated text at startup

```
Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, you should use it instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer =  true. To disable this message and keep the current (boolean) behaviour of 'exists' you can set `Redis.exists_returns_integer = false`, but this option will be removed in 5.0. (/usr/local/rvm/gems/ruby-2.6.3/gems/sidekiq-scheduler-3.0.1/lib/sidekiq-scheduler/redis_manager.rb:99:in `block in schedule_exist?')
```

Method `exists?` was added recently and most likely will not be available to everyone(https://github.com/redis/redis-rb/blame/master/lib/redis.rb#L601)