### PR TITLE
Moves Redis calls to .exists to .exists? per deprecation warning

### DIFF
--- a/lib/sidekiq-scheduler/redis_manager.rb
+++ b/lib/sidekiq-scheduler/redis_manager.rb
@@ -96,7 +96,7 @@ module SidekiqScheduler
     #
     # @return [Boolean] true if the schedules key is set, false otherwise
     def self.schedule_exist?
-      Sidekiq.redis { |r| r.exists(:schedules) }
+      Sidekiq.redis { |r| r.exists?(:schedules) }
     end
 
     # Returns all the schedule changes for a given time range.

--- a/spec/support/store.rb
+++ b/spec/support/store.rb
@@ -59,7 +59,7 @@ module SidekiqScheduler
     end
 
     def self.exists(key)
-      Sidekiq.redis { |r| r.exists(key) }
+      Sidekiq.redis { |r| r.exists?(key) }
     end
 
     def self.hexists(hash_key, field_key)


### PR DESCRIPTION
Warning:

```
`Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, you should use it instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer =  true. To disable this message and keep the current (boolean) behaviour of 'exists' you can set `Redis.exists_returns_integer = false`, but this option will be removed in 5.0.
```