### PR TITLE
Add more format examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ Cron, every, and interval types push jobs into sidekiq in a recurrent manner.
     every: '45m'    # Runs every 45 minutes
 ```
 
+The value is parsed by `Fugit::Duration#parse`. It understands quite a number of formats, including human-readable ones:
+
+``` yaml
+    every: 45 minutes
+    every: 2 hours and 30 minutes
+    every: 1.5 hours
+```
+
 `interval` is similar to `every`, the difference between them is that `interval` type schedules the
 next execution after the interval has elapsed counting from its last job enqueue.
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Cron, every, and interval types push jobs into sidekiq in a recurrent manner.
     every: '45m'    # Runs every 45 minutes
 ```
 
-The value is parsed by `Fugit::Duration#parse`. It understands quite a number of formats, including human-readable ones:
+The value is parsed by [`Fugit::Duration.parse`](https://github.com/floraison/fugit#fugitduration). It understands quite a number of formats, including human-readable ones:
 
 ``` yaml
     every: 45 minutes


### PR DESCRIPTION
Hello 🙃

I had a hard time understanding which formats for specifying periodic tasks are available. I even had to use a step debugger to get to the actual parsing code.

Here I submit my findings. Hope it will be useful to other users of this library.

Currently the README only mentions one-letter time durations. It looked like a step back from ActiveSupport-enabled durations we had in our Clockwork configuration, like `every(15.minutes)`. That prompted my little research.

Maybe the description can be improved further. Let me know 🙂