### PR TITLE
Add support for redis-rb >= 4.3

### DIFF
--- a/lib/sidekiq-scheduler/redis_manager.rb
+++ b/lib/sidekiq-scheduler/redis_manager.rb
@@ -96,7 +96,14 @@ module SidekiqScheduler
     #
     # @return [Boolean] true if the schedules key is set, false otherwise
     def self.schedule_exist?
-      Sidekiq.redis { |r| r.exists(:schedules) }
+      Sidekiq.redis do |r|
+        case r.exists(:schedules)
+        when true, 1
+          true
+        else
+          false
+        end
+      end
     end
 
     # Returns all the schedule changes for a given time range.

--- a/spec/support/store.rb
+++ b/spec/support/store.rb
@@ -59,7 +59,14 @@ module SidekiqScheduler
     end
 
     def self.exists(key)
-      Sidekiq.redis { |r| r.exists(key) }
+      Sidekiq.redis do |r|
+        case r.exists(key)
+        when true, 1
+          true
+        else
+          false
+        end
+      end
     end
 
     def self.hexists(hash_key, field_key)


### PR DESCRIPTION
Follow-up of https://github.com/moove-it/sidekiq-scheduler/pull/346

When that PR gets merged we need to add support for redis-rb >= 4.3 which will return an integer value for `exists` while prior versions return a boolean value.

Fixing the warning described in original PR https://github.com/moove-it/sidekiq-scheduler/pull/335 will be made in a future PR and will be included only in sidekiq-scheduler v4 as described here https://github.com/moove-it/sidekiq-scheduler/issues/345#issuecomment-881971975