### PR TITLE
Bump version to v3.1.1

### DIFF
--- a/lib/sidekiq-scheduler/version.rb
+++ b/lib/sidekiq-scheduler/version.rb
@@ -1,5 +1,5 @@
 module SidekiqScheduler
 
-  VERSION = '3.1.0'
+  VERSION = '3.1.1'
 
 end


### PR DESCRIPTION
This version includes:
- Docs improvements
- UI improvement switching from a table to list groups
- Use POST requests to prevent CSRF
- Brings back redis deprecation warning which will only be fixed in sidekiq-scheduler v4 (see https://github.com/moove-it/sidekiq-scheduler/issues/345)
- Add support for redis-rb >= 4.3