### PR TITLE
Fix CSS file path in web UI.

### DIFF
--- a/lib/sidekiq-scheduler/extensions/web.rb
+++ b/lib/sidekiq-scheduler/extensions/web.rb
@@ -1,6 +1,6 @@
 require 'sidekiq/web' unless defined?(Sidekiq::Web)
 
-ASSETS_PATH = File.expand_path('../../../../web/assets', __dir__)
+ASSETS_PATH = File.expand_path('../../../web/assets', __dir__)
 
 Sidekiq::Web.register(SidekiqScheduler::Web)
 Sidekiq::Web.tabs['recurring_jobs'] = 'recurring-jobs'


### PR DESCRIPTION
Commit 07b9380afc8e037789fcb02c3f7db9a8c779a0dd moved the styles to 
a separate file and mount like the rest of the Sidekiq assets.

It looks like the CSS file does not have its path properly set up.

The CSS path has been adjusted so that it loads properly now.

Before:

<img width="1455" alt="Screen Shot 2021-09-06 at 11 57 44 AM" src="https://user-images.githubusercontent.com/545604/132242474-d2d54ce9-67dc-4805-97d7-df8f5190e345.png">


After:

<img width="1463" alt="Screen Shot 2021-09-06 at 11 58 14 AM" src="https://user-images.githubusercontent.com/545604/132242484-936a229f-5bc9-43bd-afb2-90e4642601c6.png">

Fixes: #352