### PR TITLE
Fix CSS for light-mode users

### DIFF
--- a/web/assets/stylesheets/recurring_jobs.css
+++ b/web/assets/stylesheets/recurring_jobs.css
@@ -9,9 +9,9 @@
 .recurring-jobs .enqueue { margin-bottom: 0.5rem }
 
 .list-group-item {
-  background-color: #222;
-  color: white;
-  border: 1px solid #555;
+  background-color: #f3f3f3;
+  color: #585454;
+  border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
The CSS that would run for light-mode users is identical to dark mode's styles.

<img width="1490" alt="Screen Shot 2021-09-30 at 7 49 22 AM" src="https://user-images.githubusercontent.com/545604/135450431-85567574-0f13-4d8b-ba7c-03ee14f1279b.png">

This adjusts the default styles to at least match closer to the rest of Sidekiq's UI for the default theme (values "borrowed" from Sidekiq's CSS file).

<img width="1533" alt="Screen Shot 2021-09-30 at 7 49 09 AM" src="https://user-images.githubusercontent.com/545604/135450451-a7705364-fa3c-42b6-a5f9-92b79e711b94.png">
