### PR TITLE
Fix deprecated uses of `Redis#pipelined`

### DIFF
--- a/lib/sidekiq-scheduler/redis_manager.rb
+++ b/lib/sidekiq-scheduler/redis_manager.rb
@@ -137,9 +137,9 @@ module SidekiqScheduler
     def self.register_job_instance(job_name, time)
       job_key = pushed_job_key(job_name)
       registered, _ = Sidekiq.redis do |r|
-        r.pipelined do
-          r.zadd(job_key, time.to_i, time.to_i)
-          r.expire(job_key, REGISTERED_JOBS_THRESHOLD_IN_SECONDS)
+        r.pipelined do |pipeline|
+          pipeline.zadd(job_key, time.to_i, time.to_i)
+          pipeline.expire(job_key, REGISTERED_JOBS_THRESHOLD_IN_SECONDS)
         end
       end
 


### PR DESCRIPTION
Context: https://github.com/redis/redis-rb/pull/1059

The following is deprecated
```ruby
redis.pipelined do
  redis.get(key)
end
```

And should be rewritten as:
```ruby
redis.pipelined do |pipeline|
  pipeline.get(key)
end
```

Functionally it makes no difference.