### PR TITLE
fix: prevent sidekiq_options from overriding ActiveJob queue settings

### DIFF
--- a/lib/sidekiq-scheduler/schedule.rb
+++ b/lib/sidekiq-scheduler/schedule.rb
@@ -140,7 +140,9 @@ module SidekiqScheduler
     def infer_queue(klass)
       klass = try_to_constantize(klass)
 
-      if klass.respond_to?(:sidekiq_options)
+      # ActiveJob uses queue_as when the job is created
+      # to determine the queue
+      if klass.respond_to?(:sidekiq_options) && !SidekiqScheduler::Utils.active_job_enqueue?(klass)
         klass.sidekiq_options['queue']
       end
     end

--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -161,7 +161,7 @@ module SidekiqScheduler
         config['args'] = arguments_with_metadata(config['args'], scheduled_at: time.to_f)
       end
 
-      if active_job_enqueue?(config['class'])
+      if SidekiqScheduler::Utils.active_job_enqueue?(config['class'])
         SidekiqScheduler::Utils.enqueue_with_active_job(config)
       else
         SidekiqScheduler::Utils.enqueue_with_sidekiq(config)
@@ -305,17 +305,6 @@ module SidekiqScheduler
     # @return [Boolean]
     def enabled_queue?(job_queue, queues)
       queues.empty? || queues.include?(job_queue)
-    end
-
-    # Returns true if the enqueuing needs to be done for an ActiveJob
-    #  class false otherwise.
-    #
-    # @param [Class] klass the class to check is decendant from ActiveJob
-    #
-    # @return [Boolean]
-    def active_job_enqueue?(klass)
-      klass.is_a?(Class) && defined?(ActiveJob::Enqueuing) &&
-        klass.included_modules.include?(ActiveJob::Enqueuing)
     end
 
     # Convert the given arguments in the format expected to be enqueued.

--- a/lib/sidekiq-scheduler/utils.rb
+++ b/lib/sidekiq-scheduler/utils.rb
@@ -68,6 +68,17 @@ module SidekiqScheduler
       end
     end
 
+    # Returns true if the enqueuing needs to be done for an ActiveJob
+    #  class false otherwise.
+    #
+    # @param [Class] klass the class to check is decendant from ActiveJob
+    #
+    # @return [Boolean]
+    def self.active_job_enqueue?(klass)
+      klass.is_a?(Class) && defined?(ActiveJob::Enqueuing) &&
+        klass.included_modules.include?(ActiveJob::Enqueuing)
+    end
+
     # Enqueues the job using the Sidekiq client.
     #
     # @param [Hash] config The job configuration

--- a/spec/sidekiq-scheduler/schedule_spec.rb
+++ b/spec/sidekiq-scheduler/schedule_spec.rb
@@ -67,6 +67,17 @@ describe SidekiqScheduler::Schedule do
         expect(SidekiqScheduler::Store.job_from_redis(job_id)['queue']).to eq('system')
       end
     end
+
+    context 'when job is an ActiveJob job' do
+      let(:job_id) { 'email_sender' }
+      let(:schedule) { { 'class' => 'EmailSender' } }
+
+      it 'does not set the queue name' do
+        subject
+
+        expect(SidekiqScheduler::Store.job_from_redis(job_id)['queue']).to eq(nil)
+      end
+    end
   end
 
   describe '.set_schedule' do


### PR DESCRIPTION
For https://github.com/moove-it/sidekiq-scheduler/issues/303