### PR TITLE
Highlight disabled jobs

### DIFF
--- a/web/assets/stylesheets/recurring_jobs.css
+++ b/web/assets/stylesheets/recurring_jobs.css
@@ -14,6 +14,10 @@
   border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
+.list-group-item-disabled {
+  background-color: #f3d3d3;
+}
+
 @media (prefers-color-scheme: dark) {
   .list-group-item {
     background-color: #222;

--- a/web/views/recurring_jobs.erb
+++ b/web/views/recurring_jobs.erb
@@ -5,7 +5,7 @@
 <div class="recurring-jobs">
   <ul class="list-group">
     <% @presented_jobs.each do |job| %>
-      <li class="list-group-item">
+      <li class="list-group-item <%= !job.enabled? && "list-group-item-disabled" %>">
         <div class="title">
           <div class="row">
             <div class="col-xs-6">


### PR DESCRIPTION
This change adds a new CSS class to make disabled jobs more easily identifiable.

This PR resolves this issue: https://github.com/moove-it/sidekiq-scheduler/issues/368