### PR TITLE
Require redis 4.2 and fix  deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Unreleased
+
+- Require redis 4.2.0
+- Fixes redis deprecation warning regarding `exists`

--- a/lib/sidekiq-scheduler/redis_manager.rb
+++ b/lib/sidekiq-scheduler/redis_manager.rb
@@ -96,14 +96,7 @@ module SidekiqScheduler
     #
     # @return [Boolean] true if the schedules key is set, false otherwise
     def self.schedule_exist?
-      Sidekiq.redis do |r|
-        case r.exists('schedules')
-        when true, 1
-          true
-        else
-          false
-        end
-      end
+      Sidekiq.redis { |r| r.exists?('schedules') }
     end
 
     # Returns all the schedule changes for a given time range.

--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -16,18 +16,18 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5'
 
-  s.add_dependency 'sidekiq',         '>= 3'
-  s.add_dependency 'redis',           '>= 3', '< 5'
+  s.add_dependency 'sidekiq', '>= 3'
+  s.add_dependency 'redis', '>= 4.2.0'
   s.add_dependency 'rufus-scheduler', '~> 3.2'
-  s.add_dependency 'tilt',            '>= 1.4.0'
+  s.add_dependency 'tilt', '>= 1.4.0'
   s.add_dependency 'thwait'
   s.add_dependency 'e2mmap'
 
-  s.add_development_dependency 'rake',                    '~> 10.0'
+  s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'mock_redis',              '~> 0.28.0'
+  s.add_development_dependency 'mock_redis', '~> 0.28.0'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'activejob'

--- a/spec/sidekiq-scheduler/redis_manager_spec.rb
+++ b/spec/sidekiq-scheduler/redis_manager_spec.rb
@@ -262,7 +262,7 @@ describe SidekiqScheduler::RedisManager do
     it "shouldn't remove the schedules_changed if it's sorted set" do
       subject
 
-      expect(SidekiqScheduler::Store.exists('schedules_changed')).to be_truthy
+      expect(SidekiqScheduler::Store.exists?('schedules_changed')).to be true
     end
 
     context 'when schedules_changed is not a sorted set' do
@@ -274,7 +274,7 @@ describe SidekiqScheduler::RedisManager do
       it 'should remove the schedules_changed set' do
         subject
 
-        expect(SidekiqScheduler::Store.exists('schedules_changed')).to be_falsey
+        expect(SidekiqScheduler::Store.exists?('schedules_changed')).to be false
       end
     end
   end
@@ -298,7 +298,7 @@ describe SidekiqScheduler::RedisManager do
       subject
 
       Timecop.travel(SidekiqScheduler::RedisManager::REGISTERED_JOBS_THRESHOLD_IN_SECONDS) do
-        expect(SidekiqScheduler::Store.exists('sidekiq-scheduler:pushed:some_job')).to be_falsey
+        expect(SidekiqScheduler::Store.exists?('sidekiq-scheduler:pushed:some_job')).to be false
       end
     end
 

--- a/spec/support/store.rb
+++ b/spec/support/store.rb
@@ -1,6 +1,5 @@
 module SidekiqScheduler
   module Store
-
     def self.clean
       Sidekiq.redis(&:flushall)
     end
@@ -58,15 +57,8 @@ module SidekiqScheduler
       Sidekiq.redis { |r| r.zrange(zset_key, from, to) }
     end
 
-    def self.exists(key)
-      Sidekiq.redis do |r|
-        case r.exists(key)
-        when true, 1
-          true
-        else
-          false
-        end
-      end
+    def self.exists?(key)
+      Sidekiq.redis { |r| r.exists?(key) }
     end
 
     def self.hexists(hash_key, field_key)


### PR DESCRIPTION
- Fixes redis `exists` deprecation warning 
- Requires redis 4.2

Closes #345 