### PR TITLE
Remove thwait and e2mmap as dependencies

### DIFF
--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -1,5 +1,4 @@
 require 'rufus/scheduler'
-require 'thwait'
 require 'sidekiq/util'
 require 'json'
 require 'sidekiq-scheduler/rufus_utils'

--- a/sidekiq-scheduler.gemspec
+++ b/sidekiq-scheduler.gemspec
@@ -20,8 +20,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'redis', '>= 4.2.0'
   s.add_dependency 'rufus-scheduler', '~> 3.2'
   s.add_dependency 'tilt', '>= 1.4.0'
-  s.add_dependency 'thwait'
-  s.add_dependency 'e2mmap'
 
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'timecop'


### PR DESCRIPTION
They seem to be not in use, thwait has been introduced in https://github.com/moove-it/sidekiq-scheduler/pull/11 and since ruby 2.7 its not bundled with ruby anymore https://github.com/moove-it/sidekiq-scheduler/pull/299, but I can't see sidekiq-scheduler or any dependency of sidekiq-scheduler using it.

I guess these dependencies were added to prevent ruby dependency errors since 2.7 they are not bundled with it, not sure if we are safe to remove them. It will require some tests from the community, tests at least don't fail.

Closes #365 