### PR TITLE
Set rufus_scheduler_options via sidekiq.yml file as configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Available options are:
 :enabled: <enables scheduler if true [true by default]>
 :scheduler:
   :listened_queues_only: <push jobs whose queue is being listened by sidekiq [false by default]>
+:rufus_scheduler_options: <Set custom options for rufus scheduler, like max_work_threads [{} by default]>
 ```
 
 ## Schedule configuration
@@ -304,10 +305,16 @@ If you're configuring your own Redis connection pool, you need to make sure the 
 
 That's a minimum of `concurrency` + 5 (per the [Sidekiq wiki](https://github.com/mperham/sidekiq/wiki/Using-Redis#complete-control)) + `Rufus::Scheduler::MAX_WORK_THREADS` (28 as of this writing; per the [Rufus README](https://github.com/jmettraux/rufus-scheduler#max_work_threads)), for a total of 58 with the default `concurrency` of 25.
 
-You can also override the thread pool size in Rufus Scheduler by setting e.g.:
+You can also override the thread pool size in Rufus Scheduler by setting the following in your `sidekiq.yml` config:
 
-```
-SidekiqScheduler::Scheduler.instance.rufus_scheduler_options = { max_work_threads: 5 }
+```yaml
+---
+...
+
+rufus_scheduler_options:
+  max_work_threads: 5
+
+...
 ```
 
 ## Notes about running on Multiple Hosts

--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -25,6 +25,9 @@ module SidekiqScheduler
     # Set to schedule jobs only when will be pushed to queues listened by sidekiq
     attr_accessor :listened_queues_only
 
+    # Set custom options for rufus scheduler, like max_work_threads.
+    attr_accessor :rufus_scheduler_options
+
     class << self
 
       def instance
@@ -46,6 +49,7 @@ module SidekiqScheduler
       self.dynamic = options[:dynamic]
       self.dynamic_every = options[:dynamic_every]
       self.listened_queues_only = options[:listened_queues_only]
+      self.rufus_scheduler_options = options[:rufus_scheduler_options] || {}
     end
 
     # the Rufus::Scheduler jobs that are scheduled
@@ -165,14 +169,6 @@ module SidekiqScheduler
       else
         SidekiqScheduler::Utils.enqueue_with_sidekiq(config)
       end
-    end
-
-    def rufus_scheduler_options
-      @rufus_scheduler_options ||= {}
-    end
-
-    def rufus_scheduler_options=(options)
-      @rufus_scheduler_options = options
     end
 
     def rufus_scheduler

--- a/spec/sidekiq-scheduler/scheduler_spec.rb
+++ b/spec/sidekiq-scheduler/scheduler_spec.rb
@@ -4,7 +4,8 @@ describe SidekiqScheduler::Scheduler do
       enabled: true,
       dynamic: false,
       dynamic_every: '5s',
-      listened_queues_only: false
+      listened_queues_only: false,
+      rufus_scheduler_options: { max_work_threads: 5 }
     }
   end
   let(:instance) { described_class.new(scheduler_options) }
@@ -30,7 +31,8 @@ describe SidekiqScheduler::Scheduler do
         enabled: true,
         dynamic: false,
         dynamic_every: '5s',
-        listened_queues_only: false
+        listened_queues_only: false,
+        rufus_scheduler_options: { max_work_threads: 5 }
       }
     end
 
@@ -42,6 +44,12 @@ describe SidekiqScheduler::Scheduler do
 
     it { expect(subject.listened_queues_only).to be_falsey }
 
+    it { expect(subject.rufus_scheduler_options).to eql({ max_work_threads: 5 }) }
+    
+    context 'when passing rufus_scheduler_options' do
+      it { expect(instance.rufus_scheduler.max_work_threads).to eql(5) }
+    end
+
     context 'when passing no options' do
       subject { described_class.new }
 
@@ -52,6 +60,8 @@ describe SidekiqScheduler::Scheduler do
       it { expect(subject.dynamic_every).to be_nil }
 
       it { expect(subject.listened_queues_only).to be_nil }
+
+      it { expect(subject.rufus_scheduler_options).to be_empty }
     end
   end
 


### PR DESCRIPTION
This ensures that `rufus_scheduler_options` is read during boot and
`sidekiq-scheduler` instance (that also instantiates rufus scheduler)
is initialized with any custom options passed into `rufus_scheduler_options`.

Doing it this way allows us to not set the `rufus_scheduler_options`, manually
during application runtime (like below), which doesn't take into effect, due to the
memoization of `@rufus_scheduler`.

```ruby
SidekiqScheduler::Scheduler.instance.rufus_scheduler_options = { max_work_threads: 5 }
```

More about the issue here: https://github.com/moove-it/sidekiq-scheduler/issues/374
Fixes: https://github.com/moove-it/sidekiq-scheduler/issues/374