### PR TITLE
Remove config get/set depication warning due to Sidekiq 6.5+

### DIFF
--- a/lib/sidekiq-scheduler.rb
+++ b/lib/sidekiq-scheduler.rb
@@ -7,19 +7,33 @@ require_relative 'sidekiq-scheduler/manager'
 require_relative 'sidekiq-scheduler/redis_manager'
 require_relative 'sidekiq-scheduler/extensions/schedule'
 
+SIDEKIQ_GTE_6_5_0 = Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('6.5.0')
+
 Sidekiq.configure_server do |config|
 
   config.on(:startup) do
     # schedules_changed's type was changed from SET to ZSET, so we remove old versions at startup
     SidekiqScheduler::RedisManager.clean_schedules_changed
 
-    schedule_manager = SidekiqScheduler::Manager.new(config.options)
-    config.options[:schedule_manager] = schedule_manager
-    config.options[:schedule_manager].start
+    # Accessing the raw @config hash through .options is depriated in 6.5 and to be removed in 7.0
+    config_options = SIDEKIQ_GTE_6_5_0 ? Sidekiq.instance_variable_get(:@config) : config.options
+
+    schedule_manager = SidekiqScheduler::Manager.new(config_options)
+    if SIDEKIQ_GTE_6_5_0
+      config[:schedule_manager] = schedule_manager
+      config[:schedule_manager].start
+    else
+      config.options[:schedule_manager] = schedule_manager
+      config.options[:schedule_manager].start
+    end
   end
 
   config.on(:quiet) do
-    config.options[:schedule_manager].stop
+    if SIDEKIQ_GTE_6_5_0
+      config[:schedule_manager].stop
+    else
+      config.options[:schedule_manager].stop
+    end
   end
 
 end

--- a/lib/sidekiq-scheduler.rb
+++ b/lib/sidekiq-scheduler.rb
@@ -15,7 +15,7 @@ Sidekiq.configure_server do |config|
     # schedules_changed's type was changed from SET to ZSET, so we remove old versions at startup
     SidekiqScheduler::RedisManager.clean_schedules_changed
 
-    # Accessing the raw @config hash through .options is depriated in 6.5 and to be removed in 7.0
+    # Accessing the raw @config hash through .options is deprecated in 6.5 and to be removed in 7.0
     config_options = SIDEKIQ_GTE_6_5_0 ? Sidekiq.instance_variable_get(:@config) : config.options
 
     schedule_manager = SidekiqScheduler::Manager.new(config_options)

--- a/lib/sidekiq-scheduler/scheduler.rb
+++ b/lib/sidekiq-scheduler/scheduler.rb
@@ -284,7 +284,11 @@ module SidekiqScheduler
     end
 
     def sidekiq_queues
-      Sidekiq.options[:queues].map(&:to_s)
+      if SIDEKIQ_GTE_6_5_0
+        Sidekiq[:queues].map(&:to_s)
+      else
+        Sidekiq.options[:queues].map(&:to_s)
+      end
     end
 
     # Returns true if a job's queue is included in the array of queues


### PR DESCRIPTION
Closes #384 

Sidekiq 6.5 and later changed how config options work.

```ruby
 # Before
config.options[:x] = 1
config.options[:y] # => 2

 # After
config[:x] = 1
config[:y] # => 2
```

The existing functionality works, but now throws a deprication warning and will most likely be removed for Sidekiq 7. There is also no non-depricated way to access the config hash.

To maintain compatability with older Sidekiq versions, a `SIDEKIQ_GTE_6_5_0` has been added which is `true` if `Sidekiq::VERSION` is 6.5 or later. This constant is then used to determine now to pull the Sidekiq config hash and set configuration options where applicable.

This should allow the gem to maintain compatability with Sidekiq < 6.5